### PR TITLE
refactor: change argument interface declarations to type aliases 

### DIFF
--- a/src/generators/model/transformer.ts
+++ b/src/generators/model/transformer.ts
@@ -185,9 +185,9 @@ export default class Transformer {
 
           ${this.generateModelDtoInterface({ model: camelCasedModel })}
 
-          export interface ${model.name}ModelConstructorArgs ${this.generateModelConstructorType({ model: camelCasedModel })}
+          export type ${model.name}ModelConstructorArgs = ${this.generateModelConstructorType({ model: camelCasedModel })}
 
-          export interface ${model.name}ModelFromPrismaValueArgs ${this.generateStaticFromPrismaValueType({ model: camelCasedModel })}
+          export type ${model.name}ModelFromPrismaValueArgs = ${this.generateStaticFromPrismaValueType({ model: camelCasedModel })}
 
           export class ${model.name}Model {
               ${this.generateModelFields({ model: camelCasedModel })}


### PR DESCRIPTION
…r class

<!--

Thank you for your contribution! 👍

-->

## Types of changes

- [ ] Bug fixes
  - resolves #<!-- Please add issue number -->
- [ ] Features
  - resolves #<!-- Please add issue number -->
- [x] Maintenance
- [ ] Documentation

## Changes

- ...

## Additional context
- When hover to check the given type on editors like vscode, `interface` type def can't provide type info on the hover pane, so that interface needed to be changed to provide such info. `type` can do.

## Community note

<!-- Please keep this section. -->

Please upvote with reacting as :+1: to express your agreement.
