### PR TITLE
feat: Adopt generated model to be nested using includes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model Post {
   bytes     Bytes
 
   Polymorphic Polymorphic[]
+  Book_Post   Book_Post[]
 }
 
 model Book {
@@ -45,6 +46,7 @@ model Book {
   authorId Int?
 
   Polymorphic Polymorphic[]
+  Book_Post   Book_Post[]
 }
 
 model Map {
@@ -92,4 +94,16 @@ model JsonField {
   rawJson    Json
   jsonObject Json /// @json(type: [JsonObject])
   jsonArray  Json /// @json(type: [JsonArray])
+}
+
+model Book_Post {
+  id Int @id @default(autoincrement())
+
+  bookId Int
+  Book   Book @relation(fields: [bookId], references: [id])
+
+  postId Int
+  Post   Post @relation(fields: [postId], references: [id])
+
+  @@unique([bookId, postId])
 }

--- a/src/generators/model/transformer.ts
+++ b/src/generators/model/transformer.ts
@@ -314,13 +314,21 @@ export default class Transformer {
     return args.model.fields
       .filter((field) => field.relationName)
       .map((field) => {
+        const selectingModel = this._models.find(
+          (model) => model.name === field.type,
+        );
+
         return `
-          const ${field.name}WithInclude = Prisma.validator<Prisma.${field.type}DefaultArgs>()({ 
+          const ${field.type}WithInclude = Prisma.validator<Prisma.${field.type}DefaultArgs>()({ 
             include: {
-              ${changeCase.pascalCase(field.type)}: true
+              ${selectingModel?.fields
+                .filter((el) => el.relationName)
+                .map((field) => {
+                  return `${field.name}: true`;
+                })}
             }
           });
-          type ${changeCase.pascalCase(field.name)}WithIncludes = Prisma.${field.type}GetPayload<typeof ${field.name}WithInclude>;
+          type ${changeCase.pascalCase(field.type)}WithIncludes = Prisma.${field.type}GetPayload<typeof ${field.type}WithInclude>;
         `;
       })
       .join("\n");

--- a/src/generators/model/transformer.ts
+++ b/src/generators/model/transformer.ts
@@ -94,7 +94,7 @@ export default class Transformer {
 
     if (args.field.relationName) {
       return args.field.isList
-        ? `${renderKey}: ${args.field.type}WithIncludes[]`
+        ? `${renderKey}: ${changeCase.pascalCase(args.field.type)}WithIncludes[]`
         : `${renderKey}: ${args.overrideValue ? args.overrideValue : this.mapPrismaValueType({ field: args.field })}${requiredOrNullValue}`;
     }
 
@@ -204,7 +204,7 @@ export default class Transformer {
     let keyValueList = args.model.fields
       .filter((field) => field.relationName)
       .map((field) => {
-        return `${changeCase.camelCase(field.name)}${field.isRequired ? "" : "?"}: ${field.type}WithIncludes${field.isList ? "[]" : ""}`;
+        return `${changeCase.camelCase(field.name)}${field.isRequired ? "" : "?"}: ${changeCase.pascalCase(field.type)}WithIncludes${field.isList ? "[]" : ""}`;
       });
 
     const fields = this.removeRelationFromFieldsId({

--- a/src/generators/model/transformer.ts
+++ b/src/generators/model/transformer.ts
@@ -114,7 +114,7 @@ export default class Transformer {
 
   private generateModelDtoInterface(args: { model: PrismaDMMF.Model }) {
     return `
-        export interface ${args.model.name}ModelDto {
+        export type ${args.model.name}ModelDto = {
             ${args.model.fields
               .map((field) => {
                 if (field.relationName) {

--- a/src/generators/model/transformer.ts
+++ b/src/generators/model/transformer.ts
@@ -406,7 +406,12 @@ export default class Transformer {
         case "Bytes":
           return "Buffer";
         case args.field.type:
-          return `${args.field.type}WithIncludes`;
+          console.log(args.field);
+          if (args.field.relationName) {
+            return `${args.field.type}WithIncludes`;
+          }
+
+          return `Prisma${args.field.type}`;
         default:
           return "unknown";
       }


### PR DESCRIPTION
<!--

Thank you for your contribution! 👍

-->

## Types of changes

- [ ] Bug fixes
  - resolves #<!-- Please add issue number -->
- [ ] Features
  - resolves #<!-- Please add issue number -->
- [ ] Maintenance
- [ ] Documentation

## Changes

- Define include type definition when auto-gen model
  - By doing this, client code can nest the multiple include and auto gen model can handle the mutiplly nested models 

```ts
const BookWithInclude = Prisma.validator<Prisma.BookDefaultArgs>()({
  include: {
    author: true,
    Polymorphic: true,
    Book_Post: true,
  },
});
type BookWithIncludes = Prisma.BookGetPayload<typeof BookWithInclude>;

const PostWithInclude = Prisma.validator<Prisma.PostDefaultArgs>()({
  include: {
    author: true,
    Polymorphic: true,
    Book_Post: true,
  },
});
type PostWithIncludes = Prisma.PostGetPayload<typeof PostWithInclude>;

export type Book_PostModelDto = {
  id: number;
  book: BookWithIncludes;
  post: PostWithIncludes;
};

export type Book_PostModelConstructorArgs = {
  id: number;
  book: BookWithIncludes;
  post: PostWithIncludes;
};

export type Book_PostModelFromPrismaValueArgs = {
  self: PrismaBook_Post;
  book: BookWithIncludes;
  post: PostWithIncludes;
};
```

## Additional context

## Community note

<!-- Please keep this section. -->

Please upvote with reacting as :+1: to express your agreement.
