### PR TITLE
fix:Convert field name Snake case to Camel case

### DIFF
--- a/src/generators/model/transformer.ts
+++ b/src/generators/model/transformer.ts
@@ -253,6 +253,10 @@ export default class Transformer {
             }`;
   }
 
+  private toCamelCase(input: string): string {
+    return input.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+  }
+
   private removeRelationFromFieldsId(args: {
     model: PrismaDMMF.Model;
     mutatingList: string[];
@@ -263,7 +267,7 @@ export default class Transformer {
       if (field.relationName) {
         field.relationFromFields?.forEach((relationField) => {
           mutatingList = mutatingList.filter((keyValue) => {
-            return !keyValue.includes(relationField);
+            return !keyValue.includes(this.toCamelCase(relationField));
           });
         });
       }

--- a/src/generators/model/transformer.ts
+++ b/src/generators/model/transformer.ts
@@ -253,10 +253,6 @@ export default class Transformer {
             }`;
   }
 
-  private toCamelCase(input: string): string {
-    return input.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
-  }
-
   private removeRelationFromFieldsId(args: {
     model: PrismaDMMF.Model;
     mutatingList: string[];
@@ -267,7 +263,7 @@ export default class Transformer {
       if (field.relationName) {
         field.relationFromFields?.forEach((relationField) => {
           mutatingList = mutatingList.filter((keyValue) => {
-            return !keyValue.includes(this.toCamelCase(relationField));
+            return !keyValue.includes(changeCase.camelCase(relationField));
           });
         });
       }


### PR DESCRIPTION
<!--

Thank you for your contribution! 👍

-->

## Types of changes

- [ ●] Bug fixes
  - resolves #<!-- Please add issue number -->
- [ ] Features
  - resolves #<!-- Please add issue number -->
- [ ] Maintenance
- [ ] Documentation

## Changes
Added processing to convert to CamelCase when SnakeCase is given in the field name.
- ...

## Additional context
Snake cases can be assumed to be used in the field of the relation destination, but only the necessary types need to be passed to fromPrismaValue, but due to a mismatch between the key name and value name, unnecessary ones were added.

The appearance of the error is attributed to version 2.0.0
（feat: Adopt generated model to be nested using includes #34）




## Community note

<!-- Please keep this section. -->

Please upvote with reacting as :+1: to express your agreement.
