### PR TITLE
fix: include repository generator in npm package

### DIFF
--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -2,32 +2,54 @@
 
 Run the full release pipeline: version bump, build, PR, merge, and npm publish.
 
+### Versioning
+
+Version format: `{prisma_major}.{prisma_minor}.0-rev{N}`
+
+- The major.minor MUST match Prisma's `@prisma/client` version in `package.json` dependencies
+- The `-revN` suffix is our own revision counter for changes independent of Prisma
+- First release for a Prisma version: `7.7.0-rev1`
+- Subsequent releases: `7.7.0-rev2`, `7.7.0-rev3`, etc.
+- When Prisma bumps: reset to `X.Y.0-rev1`
+
+Examples:
+- Prisma 7.7.0, first release → `7.7.0-rev1`
+- Prisma 7.7.0, second release → `7.7.0-rev2`
+- Prisma 7.8.0, first release → `7.8.0-rev1`
+
 ### Steps
 
-1. **Determine version**: Read `@prisma/client` version from `package.json` dependencies. The package version MUST align with Prisma's major.minor (e.g., Prisma 7.6.0 -> package 7.6.0). If a same major.minor version is already published, use the next patch (e.g., 7.6.1).
+1. **Determine version**: Read `@prisma/client` version from `package.json` dependencies. Check `npm view frourio-framework-prisma-generators versions --json` for published versions. Use the next `-revN` for the current Prisma major.minor.
 
 2. **Typecheck**: Run `npm run typecheck` and confirm it passes.
 
-3. **Build & Generate**: Run `npm run generate` and confirm models are generated correctly.
+3. **Test**: Run `npm run test` and confirm it passes.
 
-4. **Bump version**: Update `version` in both `package.json` and `package/package.json`, then run `npm install --package-lock-only` to sync `package-lock.json`.
+4. **Build & Generate**: Run `npm run generate` and confirm models are generated correctly. Verify that `lib/generators/repository/` exists (repository generator must be included).
 
-5. **Commit version bump**: Commit the version change files (`package.json`, `package/package.json`, `package-lock.json`).
+5. **Bump version**: Update `version` in `package.json`, then run `npm install --package-lock-only` to sync `package-lock.json`.
 
-6. **Push & Create PR**: Push the branch and create a PR to `main` with a summary of changes.
+6. **Commit version bump**: Commit the version change files (`package.json`, `package-lock.json`).
 
-7. **Merge PR**: After PR is created, merge it to `main`.
+7. **Push & Create PR**: Push the branch and create a PR to `main` with a summary of changes.
 
-8. **Checkout main & pull**: Switch to `main` and pull the merged changes.
+8. **Merge PR**: After PR is created, merge it to `main`.
 
-9. **Build package**: Run `./package.sh` to build the publishable package.
+9. **Checkout main & pull**: Switch to `main` and pull the merged changes.
 
-10. **Handle lock file changes**: If `npm update` causes uncommitted changes, commit them before proceeding.
+10. **Build package**: Run `./package.sh` to build the publishable package.
 
-11. **Publish**: Run `cd package && npm publish`. Authentication is configured in `~/.npmrc`.
+11. **Verify package**: Confirm `package/lib/generators/repository/` exists. Confirm `package/package.json` has both `bin` entries (model and repository generators).
 
-12. **Push main**: Push the final state of `main` to origin.
+12. **Handle lock file changes**: If `npm update` causes uncommitted changes, commit them before proceeding.
+
+13. **Publish**: Run `cd package && npm publish`. Authentication is configured in `~/.npmrc`.
+
+14. **Tag**: Create and push a git tag: `git tag v{version} && git push origin v{version}`.
+
+15. **Push main**: Push the final state of `main` to origin.
 
 ### Notes
 - Always check `npm view frourio-framework-prisma-generators versions --json` to verify which versions are already published.
 - The `package:publish` script may fail on `check-uncommitted` if `npm update` modifies `package-lock.json`. In that case, build and publish manually with `./package.sh && cd package && npm publish`.
+- `@types/node` is in `dependencies` (not devDependencies) to prevent npm peer resolution issues on Node 24+.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "frourio-framework-prisma-generators",
-  "version": "7.3.0",
+  "version": "7.7.0-rev1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frourio-framework-prisma-generators",
-      "version": "7.3.0",
+      "version": "7.7.0-rev1",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^7.2.0",
         "@prisma/generator-helper": "^7.2.0",
         "@prisma/internals": "^7.2.0",
+        "@types/node": ">=20.0.0",
         "change-case-all": "^2.1.0",
         "prettier": "^3.5.3"
       },
@@ -20,7 +21,6 @@
         "frourio-framework-prisma-repository-generator": "lib/generators/repository/generator.js"
       },
       "devDependencies": {
-        "@types/node": "^24.0.0",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
         "@typescript-eslint/parser": "^8.58.0",
         "eslint": "^10.2.0",
@@ -1575,14 +1575,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-      "dev": true,
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/react": {
@@ -4169,10 +4168,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frourio-framework-prisma-generators",
-  "version": "7.3.0",
+  "version": "7.7.0-rev1",
   "description": "",
   "bin": {
     "frourio-framework-prisma-model-generator": "lib/generators/model/generator.js",
@@ -36,11 +36,11 @@
     "@prisma/client": "^7.2.0",
     "@prisma/generator-helper": "^7.2.0",
     "@prisma/internals": "^7.2.0",
+    "@types/node": ">=20.0.0",
     "change-case-all": "^2.1.0",
     "prettier": "^3.5.3"
   },
   "devDependencies": {
-    "@types/node": "^24.0.0",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
     "eslint": "^10.2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "allowSyntheticDefaultImports": true,
     "target": "es2019",
     "lib": ["es2019", "DOM"],
+    "types": ["node"],
     "noImplicitAny": true,
     "moduleResolution": "node",
     "declaration": true,


### PR DESCRIPTION
## Summary
- `@types/node` を devDependencies → dependencies に移動（npm 11+ / Node 24 で peer 扱いされてインストールされない問題の修正）
- `tsconfig.json` に `"types": ["node"]` 追加で明示的な型解決
- バージョンを `7.7.0-rev1` に更新（新semver: Prisma major.minor + revN）
- `publish.md` に新バージョニング方針と repository generator 検証ステップ追加

## Root Cause
npm 11 が `@types/node` を peer dependency として解決し、実際にインストールしない → `tsc` で Node built-in モジュール（fs, path）の型解決失敗 → `lib/generators/repository/` が生成されない → npm publish にrepository generator が含まれない

## Test plan
- [ ] `npm install` 後 `node_modules/@types/node` が存在すること
- [ ] `npx tsc` がエラーなしで完了すること
- [ ] `lib/generators/repository/` が生成されること
- [ ] `./package.sh` 後 `package/lib/generators/repository/` が存在すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)