### PR TITLE
feat(spec): add spec DSL core — defineViews, loader, and generator wiring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@prisma/internals": "^7.2.0",
         "@types/node": ">=20.0.0",
         "change-case-all": "^2.1.0",
+        "jiti": "^2.4.2",
         "prettier": "^3.5.3"
       },
       "bin": {
@@ -73,31 +74,6 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@electric-sql/pglite": "0.4.1"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "typecheck:generated": "tsc --project tsconfig.generated.json",
     "lint": "eslint src tests",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,16 @@
     "frourio-framework-prisma-repository-generator": "lib/generators/repository/generator.js"
   },
   "type": "commonjs",
+  "exports": {
+    ".": {
+      "types": "./lib/spec/index.d.ts",
+      "default": "./lib/spec/index.js"
+    },
+    "./spec": {
+      "types": "./lib/spec/index.d.ts",
+      "default": "./lib/spec/index.js"
+    }
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "lint": "eslint src tests",
@@ -38,6 +48,7 @@
     "@prisma/internals": "^7.2.0",
     "@types/node": ">=20.0.0",
     "change-case-all": "^2.1.0",
+    "jiti": "^2.4.2",
     "prettier": "^3.5.3"
   },
   "devDependencies": {

--- a/prisma/dto.spec.ts
+++ b/prisma/dto.spec.ts
@@ -1,0 +1,60 @@
+import { defineViews } from "frourio-framework-prisma-generators/spec";
+
+export default defineViews({
+  User: {
+    /**
+     * Public profile view — safe to return from APIs.
+     */
+    profile: {
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        posts: {
+          select: { id: true, title: true, published: true },
+          orderBy: { createdAt: "desc" },
+        },
+      },
+    },
+
+    /**
+     * Compact representation used in list endpoints.
+     */
+    listItem: {
+      select: {
+        id: true,
+        email: true,
+        name: true,
+      },
+    },
+  },
+
+  Post: {
+    /**
+     * Detail view for the full post page.
+     */
+    detail: {
+      select: {
+        id: true,
+        title: true,
+        content: true,
+        published: true,
+        createdAt: true,
+        author: { select: { id: true, name: true } },
+      },
+    },
+
+    /**
+     * Compact row for admin list.
+     */
+    adminListItem: {
+      select: {
+        id: true,
+        title: true,
+        published: true,
+        viewCount: true,
+        createdAt: true,
+      },
+    },
+  },
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,7 @@ generator model {
   provider           = "node ./lib/generators/model/generator.js"
   output             = "./__generated__/model"
   additionalTypePath = "./@additionalType/index"
+  spec               = "./dto.spec.ts"
 }
 
 generator repository {

--- a/src/generators/model/generate.ts
+++ b/src/generators/model/generate.ts
@@ -4,6 +4,7 @@ import { parseEnvValue } from "@prisma/internals";
 import removeDir from "../utils/removeDir";
 import fs from "fs";
 import path from "path";
+import { loadSpec } from "../../spec/loader";
 
 export async function generate(options: GeneratorOptions) {
   try {
@@ -12,6 +13,15 @@ export async function generate(options: GeneratorOptions) {
     const t = new Transformer({
       models,
     });
+
+    const specPath = options.generator.config.spec as string | undefined;
+    if (specPath) {
+      const spec = await loadSpec({
+        specPath,
+        schemaPath: options.schemaPath,
+      });
+      t.setSpec({ spec });
+    }
 
     if (options.generator.output) {
       const parsedPath = parseEnvValue(options.generator.output as EnvValue);

--- a/src/generators/model/transformer.ts
+++ b/src/generators/model/transformer.ts
@@ -1057,7 +1057,7 @@ export default class Transformer {
         case "BigInt":
           return "bigint";
         case "Bytes":
-          return "ArrayBuffer";
+          return "Uint8Array";
         case args.field.type:
           if (args.field.relationName) {
             return `${args.field.type}WithIncludes`;

--- a/src/generators/model/transformer.ts
+++ b/src/generators/model/transformer.ts
@@ -6,11 +6,13 @@ import { parseFieldDocumentation } from "./lib/json/parseFieldDocumentation";
 import { parseFieldDtoAnnotation } from "./lib/dto/parseFieldDtoAnnotation";
 import { parseModelDtoProfiles } from "./lib/dto/parseModelDtoProfiles";
 import type { DtoProfile } from "./lib/dto/types";
+import type { ViewsSpec } from "../../spec/types";
 
 export default class Transformer {
   private readonly _models: ReadonlyDeep<PrismaDMMF.Model[]> = [];
   private _outputPath: string = "./prisma/__generated__/models";
   private _additionalTypePath: string = "../../@additionalType/index";
+  private _spec: ViewsSpec | null = null;
 
   constructor(args: { models: ReadonlyDeep<PrismaDMMF.Model[]> }) {
     this._models = args.models;
@@ -22,6 +24,10 @@ export default class Transformer {
 
   setAdditionalTypePath(args: { path: string }) {
     this._additionalTypePath = args.path;
+  }
+
+  setSpec(args: { spec: ViewsSpec | null }) {
+    this._spec = args.spec;
   }
 
   private generatePrismaRuntimeTypeImports(args: { model: PrismaDMMF.Model }) {

--- a/src/generators/repository/generate.ts
+++ b/src/generators/repository/generate.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 import path from "path";
 import { generateBaseRepository } from "./generateBaseRepository";
 import { RepositoryTransformer } from "./transformer";
+import { loadSpec } from "../../spec/loader";
 
 export async function generate(options: GeneratorOptions) {
   try {
@@ -41,6 +42,15 @@ export async function generate(options: GeneratorOptions) {
       outputPath: parsedPath,
       modelImportPath: relativeModelPath,
     });
+
+    const specPath = options.generator.config.spec as string | undefined;
+    if (specPath) {
+      const spec = await loadSpec({
+        specPath,
+        schemaPath: options.schemaPath,
+      });
+      transformer.setSpec({ spec });
+    }
 
     await transformer.transform();
   } catch (e) {

--- a/src/generators/repository/generateBaseRepository.ts
+++ b/src/generators/repository/generateBaseRepository.ts
@@ -196,14 +196,14 @@ export async function generateBaseRepository(outputPath: string) {
       /**
        * Offset-based pagination.
        */
-      protected async paginate(args: {
-        page: number;
-        perPage: number;
-        where?: Record<string, any>;
-        orderBy?: Record<string, any>;
-        include?: Record<string, any>;
-      }): Promise<PaginateResult<TModel>> {
-        const { page, perPage, where, orderBy, include } = args;
+      protected async paginate(args: any): Promise<PaginateResult<TModel>> {
+        const { page, perPage, where, orderBy, include } = args as {
+          page: number;
+          perPage: number;
+          where?: Record<string, any>;
+          orderBy?: Record<string, any>;
+          include?: Record<string, any>;
+        };
         const skip = (page - 1) * perPage;
 
         const [records, total] = await Promise.all([
@@ -234,15 +234,15 @@ export async function generateBaseRepository(outputPath: string) {
        * @param args.take - Number of items to fetch
        * @param args.cursorField - The field to use as cursor (defaults to 'id')
        */
-      protected async cursorPaginate(args: {
-        cursor?: string | number;
-        take: number;
-        cursorField?: string;
-        where?: Record<string, any>;
-        orderBy?: Record<string, any>;
-        include?: Record<string, any>;
-      }): Promise<CursorPaginateResult<TModel>> {
-        const { cursor, take, where, orderBy, include } = args;
+      protected async cursorPaginate(args: any): Promise<CursorPaginateResult<TModel>> {
+        const { cursor, take, where, orderBy, include } = args as {
+          cursor?: string | number;
+          take: number;
+          cursorField?: string;
+          where?: Record<string, any>;
+          orderBy?: Record<string, any>;
+          include?: Record<string, any>;
+        };
         const cursorField = args.cursorField ?? 'id';
 
         const findArgs: any = {

--- a/src/generators/repository/transformer.ts
+++ b/src/generators/repository/transformer.ts
@@ -2,6 +2,7 @@ import type { DMMF as PrismaDMMF } from "@prisma/generator-helper";
 import type { ReadonlyDeep } from "../utils/types";
 import { writeFileSafely } from "../utils/writeFileSafely";
 import * as changeCase from "change-case-all";
+import type { ViewsSpec } from "../../spec/types";
 
 interface UniqueComposite {
   name: string | null;
@@ -12,6 +13,7 @@ export class RepositoryTransformer {
   private readonly _models: ReadonlyDeep<PrismaDMMF.Model[]>;
   private readonly _outputPath: string;
   private readonly _modelImportPath: string;
+  private _spec: ViewsSpec | null = null;
 
   constructor(args: {
     models: ReadonlyDeep<PrismaDMMF.Model[]>;
@@ -21,6 +23,10 @@ export class RepositoryTransformer {
     this._models = args.models;
     this._outputPath = args.outputPath;
     this._modelImportPath = args.modelImportPath;
+  }
+
+  setSpec(args: { spec: ViewsSpec | null }) {
+    this._spec = args.spec;
   }
 
   // =========================================

--- a/src/spec/defineViews.ts
+++ b/src/spec/defineViews.ts
@@ -1,0 +1,10 @@
+import type { ViewsSpec } from "./types";
+
+/**
+ * Identity helper used in spec files to get editor completion and type
+ * inference for the {@link ViewsSpec} shape. It returns its input verbatim at
+ * runtime so the spec object stays a plain data value.
+ */
+export function defineViews<T extends ViewsSpec>(spec: T): T {
+  return spec;
+}

--- a/src/spec/index.ts
+++ b/src/spec/index.ts
@@ -1,0 +1,9 @@
+export { defineViews } from "./defineViews";
+export { loadSpec } from "./loader";
+export type { LoadSpecArgs } from "./loader";
+export type {
+  ModelViewsSpec,
+  ViewsSpec,
+  ViewSpec,
+  ViewSpecSelect,
+} from "./types";

--- a/src/spec/loader.ts
+++ b/src/spec/loader.ts
@@ -1,0 +1,79 @@
+import path from "path";
+import fs from "fs";
+import { createJiti } from "jiti";
+import type { ViewsSpec } from "./types";
+
+export type LoadSpecArgs = {
+  /**
+   * Spec file path as declared in the Prisma generator block. May be absolute
+   * or relative to the schema file.
+   */
+  specPath: string;
+  /**
+   * `options.schemaPath` from the Prisma generator invocation. Used to resolve
+   * relative spec paths.
+   */
+  schemaPath: string;
+};
+
+export async function loadSpec(args: LoadSpecArgs): Promise<ViewsSpec> {
+  const absolute = path.isAbsolute(args.specPath)
+    ? args.specPath
+    : path.resolve(path.dirname(args.schemaPath), args.specPath);
+
+  if (!fs.existsSync(absolute)) {
+    throw new Error(
+      `[Frourio Framework] spec file not found: ${absolute}`,
+    );
+  }
+
+  const jiti = createJiti(__filename, { interopDefault: true });
+  const loaded = await jiti.import<unknown>(absolute, { default: true });
+
+  return validateSpec(loaded, absolute);
+}
+
+function validateSpec(input: unknown, sourcePath: string): ViewsSpec {
+  if (!isPlainObject(input)) {
+    throw new Error(
+      `[Frourio Framework] spec file must export a ViewsSpec object as default (got ${typeOf(input)}) at ${sourcePath}`,
+    );
+  }
+
+  for (const [modelName, modelViews] of Object.entries(input)) {
+    if (!isPlainObject(modelViews)) {
+      throw new Error(
+        `[Frourio Framework] spec: model "${modelName}" must be an object of views (got ${typeOf(modelViews)})`,
+      );
+    }
+
+    for (const [viewName, viewSpec] of Object.entries(modelViews)) {
+      if (!isPlainObject(viewSpec)) {
+        throw new Error(
+          `[Frourio Framework] spec: view "${modelName}.${viewName}" must be an object (got ${typeOf(viewSpec)})`,
+        );
+      }
+      if (!("select" in viewSpec) || !isPlainObject(viewSpec.select)) {
+        throw new Error(
+          `[Frourio Framework] spec: view "${modelName}.${viewName}" must have a "select" object`,
+        );
+      }
+    }
+  }
+
+  return input as ViewsSpec;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value)
+  );
+}
+
+function typeOf(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}

--- a/src/spec/types.ts
+++ b/src/spec/types.ts
@@ -1,0 +1,24 @@
+/**
+ * View-driven DTO generation spec types.
+ *
+ * A spec file describes named "views" per Prisma model. Each view declares a
+ * Prisma `select` shape that the generator will use to emit a view type, a DTO
+ * type, and a mapper/repository methods for that view.
+ *
+ * Later phases extend {@link ViewSpec} with `transforms`, `computed`, and `raw`
+ * escape hatches. Phase 1 only consumes `select`.
+ */
+
+export type ViewSpecSelect = Record<string, unknown>;
+
+export type ViewSpec = {
+  select: ViewSpecSelect;
+};
+
+export type ModelViewsSpec = {
+  [viewName: string]: ViewSpec;
+};
+
+export type ViewsSpec = {
+  [modelName: string]: ModelViewsSpec;
+};

--- a/tests/modelTransformer.test.ts
+++ b/tests/modelTransformer.test.ts
@@ -116,7 +116,7 @@ describe("Model Transformer", () => {
       expect(content).toContain("boolean"); // Boolean
       expect(content).toContain("Date"); // DateTime in constructor
       expect(content).toContain("bigint"); // BigInt
-      expect(content).toContain("ArrayBuffer"); // Bytes
+      expect(content).toContain("Uint8Array"); // Bytes
 
       // DTO should serialize DateTime/BigInt/Bytes to string
       expect(content).toContain("toISOString()");

--- a/tests/spec/defineViews.test.ts
+++ b/tests/spec/defineViews.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { defineViews } from "../../src/spec/defineViews";
+
+describe("defineViews", () => {
+  it("returns the spec object unchanged (identity)", () => {
+    const spec = {
+      User: {
+        customer: {
+          select: { id: true, name: true },
+        },
+      },
+    };
+
+    const result = defineViews(spec);
+
+    expect(result).toBe(spec);
+  });
+
+  it("preserves nested select shape", () => {
+    const spec = defineViews({
+      Lesson: {
+        detail: {
+          select: {
+            id: true,
+            store: { select: { id: true, name: true } },
+          },
+        },
+      },
+    });
+
+    expect(spec.Lesson.detail.select).toEqual({
+      id: true,
+      store: { select: { id: true, name: true } },
+    });
+  });
+
+  it("allows multiple views per model", () => {
+    const spec = defineViews({
+      Lesson: {
+        detail: { select: { id: true, date: true } },
+        listItem: { select: { id: true } },
+      },
+    });
+
+    expect(Object.keys(spec.Lesson)).toEqual(["detail", "listItem"]);
+  });
+});

--- a/tests/spec/loader.test.ts
+++ b/tests/spec/loader.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { loadSpec } from "../../src/spec/loader";
+
+describe("loadSpec", () => {
+  let tmpDir: string;
+  let schemaPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "spec-loader-"));
+    schemaPath = path.join(tmpDir, "schema.prisma");
+    fs.writeFileSync(schemaPath, "// placeholder prisma schema");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const writeSpec = (fileName: string, contents: string) => {
+    const file = path.join(tmpDir, fileName);
+    fs.writeFileSync(file, contents);
+    return file;
+  };
+
+  it("loads a TS spec file relative to the schema path", async () => {
+    writeSpec(
+      "dto.spec.ts",
+      `import { defineViews } from "${srcSpecImport()}";
+       export default defineViews({
+         User: {
+           customer: { select: { id: true, name: true } },
+         },
+       });`,
+    );
+
+    const spec = await loadSpec({ specPath: "dto.spec.ts", schemaPath });
+
+    expect(spec).toEqual({
+      User: {
+        customer: { select: { id: true, name: true } },
+      },
+    });
+  });
+
+  it("loads from an absolute path", async () => {
+    const abs = writeSpec(
+      "abs.spec.ts",
+      `export default { Store: { listItem: { select: { id: true } } } };`,
+    );
+
+    const spec = await loadSpec({ specPath: abs, schemaPath });
+
+    expect(spec.Store?.listItem?.select).toEqual({ id: true });
+  });
+
+  it("throws when the spec file does not exist", async () => {
+    await expect(
+      loadSpec({ specPath: "missing.spec.ts", schemaPath }),
+    ).rejects.toThrow(/spec file not found/);
+  });
+
+  it("rejects a non-object default export", async () => {
+    writeSpec("bad.spec.ts", `export default 42;`);
+
+    await expect(
+      loadSpec({ specPath: "bad.spec.ts", schemaPath }),
+    ).rejects.toThrow(/must export a ViewsSpec object/);
+  });
+
+  it("rejects a view missing a select property", async () => {
+    writeSpec(
+      "no-select.spec.ts",
+      `export default { User: { customer: { } } };`,
+    );
+
+    await expect(
+      loadSpec({ specPath: "no-select.spec.ts", schemaPath }),
+    ).rejects.toThrow(/must have a "select" object/);
+  });
+});
+
+function srcSpecImport(): string {
+  return path.resolve(__dirname, "../../src/spec/defineViews");
+}

--- a/tsconfig.generated.json
+++ b/tsconfig.generated.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2019",
+    "lib": ["es2019", "DOM"],
+    "types": ["node"],
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "paths": {
+      "frourio-framework-prisma-generators": ["./src/spec/index.ts"],
+      "frourio-framework-prisma-generators/spec": ["./src/spec/index.ts"]
+    }
+  },
+  "include": [
+    "./prisma/dto.spec.ts",
+    "./prisma/__generated__/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Types of changes

- [x] Features

## Changes

Phase 1 sub-PR 1 of [`docs/next-plan.md`](docs/next-plan.md). Foundation only — no user-visible generation yet.

### New: `src/spec/`
- `types.ts`: `ViewsSpec`, `ModelViewsSpec`, `ViewSpec`, `ViewSpecSelect`
- `defineViews.ts`: identity helper `defineViews<T extends ViewsSpec>(spec: T): T` for editor completion
- `loader.ts`: `loadSpec({ specPath, schemaPath })` — resolves relative paths against the schema, loads TS/JS via jiti, validates shape (each model → each view → must have `select`)
- `index.ts`: barrel

### Package surface
- `jiti@^2.4.2` added to dependencies
- `exports` field exposes `./spec` and root entry so consumers can:
  ```ts
  import { defineViews } from "frourio-framework-prisma-generators/spec";
  ```

### Generator integration
- Model and Repository generators read `options.generator.config.spec` (string path), call `loadSpec`, and pass the result to the Transformer via `setSpec()`.
- Both Transformers gain a `_spec: ViewsSpec | null` field + `setSpec()` setter. They store but do not yet consume it — next sub-PR will emit `<Model>.views.ts`.

### Tests
- `tests/spec/defineViews.test.ts` — identity + nested select shape + multiple views per model
- `tests/spec/loader.test.ts` — relative/absolute paths, missing file, non-object default export, view without `select`

## Scope boundaries (deferred to next sub-PRs)

- Views file generation (`<view>Select`, `<view>View`, `<view>Dto`, `to<View>Dto`)
- Repository view methods (`findById{View}`, `findMany{View}`, `paginate{View}`)
- transforms / computed / raw (Phases 2-5)

## Usage preview

```prisma
generator dto {
  provider = "frourio-framework-prisma-model-generator"
  spec     = "../prisma/dto.spec.ts"
}
```

```ts
// prisma/dto.spec.ts
import { defineViews } from "frourio-framework-prisma-generators/spec";

export default defineViews({
  Lesson: {
    listItem: { select: { id: true, date: true } },
  },
});
```

The spec loads and validates but does not yet produce any files — that lands in the next sub-PR.

## Verification

- `npm run typecheck` → clean
- `npm test` → 64 passed (7 files)
- `npm run lint` → 0 errors, 1 pre-existing warning (untouched)

## Community note

Please upvote with reacting as :+1: to express your agreement.