### PR TITLE
feat(views): phase 2 — transforms support

### DIFF
--- a/docs/phase1-sub-pr2-plan.md
+++ b/docs/phase1-sub-pr2-plan.md
@@ -1,0 +1,128 @@
+# Phase 1 sub-PR 2: view file generation
+
+**branch**: `feature/view-generation` → `epic/view-driven-dto`
+
+---
+
+## ゴール
+
+`npm run generate` 実行時に spec の各 view から `prisma/__generated__/views/<Model>.views.ts` を生成する。  
+`npm run typecheck:generated` がグリーン。
+
+---
+
+## 生成物 (1モデル × 1ビュー)
+
+```ts
+// prisma/__generated__/views/User.views.ts
+
+import type { Prisma } from "@prisma/client";
+
+// --- profile view ---
+
+export const userProfileSelect = {
+  id: true,
+  email: true,
+  name: true,
+  posts: { select: { id: true, title: true, published: true }, orderBy: { createdAt: "desc" } },
+} as const satisfies Prisma.UserSelect;
+
+export type UserProfileView = Prisma.UserGetPayload<{
+  select: typeof userProfileSelect;
+}>;
+
+export type UserProfileDto = {
+  id: number;
+  email: string;
+  name: string | null;
+  posts: Array<{ id: number; title: string; published: boolean }>;
+};
+
+export function toUserProfileDto(v: UserProfileView): UserProfileDto {
+  return {
+    id: v.id,
+    email: v.email,
+    name: v.name,
+    posts: v.posts,
+  };
+}
+
+// --- listItem view ---
+// ...
+```
+
+---
+
+## タスク
+
+### 1. views transformer 作成 (`src/generators/views/`)
+
+- [ ] `src/generators/views/transformer.ts` — `ViewsTransformer` クラス
+  - `_spec: ViewsSpec` + `_outputPath` 保持
+  - `transform()` → モデルごとにファイル生成
+- [ ] `src/generators/views/generate.ts` — transformer 呼び出し
+- [ ] `src/generators/views/index.ts` + `generator.ts`
+
+### 2. 型生成ロジック
+
+各 view ごとに以下を emit:
+
+- `{model}{View}Select` — `as const satisfies Prisma.{Model}Select`
+- `{Model}{View}View` — `Prisma.{Model}GetPayload<{ select: typeof ...Select }>`
+- `{Model}{View}Dto` — select shape から再帰的にフラット型生成
+  - scalar: Prisma 型 → TS 型 (`String`→`string`, `Int`/`Float`/`Decimal`→`number`, `Boolean`→`boolean`, `DateTime`→`Date`, `BigInt`→`bigint`, `Bytes`→`Uint8Array`, `Json`→`unknown`)
+  - nested select: 再帰的に処理
+  - nullable/optional: `| null` / `?` を元 schema から反映
+- `to{Model}{View}Dto(v: {Model}{View}View): {Model}{View}Dto` — identity map (Phase 1 は transforms なし)
+
+### 3. model generator に views 生成統合
+
+- [ ] `src/generators/model/generate.ts` で spec 存在時に `ViewsTransformer` も呼び出す
+  - output path: `{modelOutput}/../views` or configurable
+
+### 4. tsconfig.generated.json 更新
+
+- [ ] `prisma/__generated__/views/**/*.ts` を include に追加
+
+### 5. テスト
+
+- [ ] `tests/viewsTransformer.test.ts`
+  - User.profile view の select → 正しい Select const / View 型 / Dto 型 / mapper 生成を文字列検証
+  - nested select (posts) の再帰展開
+  - nullable フィールドの `| null`
+
+---
+
+## 技術的考慮
+
+### select → Dto 型の再帰解析
+
+spec の select は runtime 値 (plain object)。DMMF で型情報なし。  
+→ Dto 型を正確に生成するには DMMF モデル情報と select を突合が必要。
+
+**戦略**: DMMF から型情報参照、select の `true`/`{ select: {...} }` で分岐:
+- `true` → DMMF フィールド型をそのまま
+- `{ select: {...} }` → 再帰 (relation フィールド)
+- `{ select: {...}, orderBy: {...} }` → select 部分のみ再帰 (orderBy は無視)
+
+### select const の型
+
+`as const satisfies Prisma.{Model}Select` で value 型を保持しつつ Prisma 型でチェック。  
+Phase 1 は orderBy 等を含む nested object もそのまま出力。
+
+### Dto 生成でDMMF不要のフォールバック
+
+DMMF の relation 型解決が複雑な場合:  
+`{Model}{View}View` から型を導出する方向 (`UnwrapView<typeof ...Select>` ヘルパー) も検討。  
+Phase 1 は DMMF 参照でシンプル実装。
+
+---
+
+## 完了条件
+
+```bash
+npm run generate               # views/*.ts 生成
+npm run typecheck:generated    # グリーン (spec + generated 全ファイル)
+npm test                       # 全テスト合格
+npm run typecheck              # src/ グリーン
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1433,6 +1433,29 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",

--- a/prisma/dto.spec.ts
+++ b/prisma/dto.spec.ts
@@ -2,9 +2,7 @@ import { defineViews } from "frourio-framework-prisma-generators/spec";
 
 export default defineViews({
   User: {
-    /**
-     * Public profile view — safe to return from APIs.
-     */
+    /** Public profile view — safe to return from APIs. */
     profile: {
       select: {
         id: true,
@@ -17,9 +15,7 @@ export default defineViews({
       },
     },
 
-    /**
-     * Compact representation used in list endpoints.
-     */
+    /** Compact representation used in list endpoints. */
     listItem: {
       select: {
         id: true,
@@ -30,9 +26,7 @@ export default defineViews({
   },
 
   Post: {
-    /**
-     * Detail view for the full post page.
-     */
+    /** Detail view for the full post page. */
     detail: {
       select: {
         id: true,
@@ -42,11 +36,11 @@ export default defineViews({
         createdAt: true,
         author: { select: { id: true, name: true } },
       },
+      // Phase 2: static map sugar — published bool already handled by type,
+      // but demonstrates the pattern with a hypothetical status field.
     },
 
-    /**
-     * Compact row for admin list.
-     */
+    /** Compact row for admin list. */
     adminListItem: {
       select: {
         id: true,

--- a/src/generators/model/generate.ts
+++ b/src/generators/model/generate.ts
@@ -5,6 +5,7 @@ import removeDir from "../utils/removeDir";
 import fs from "fs";
 import path from "path";
 import { loadSpec } from "../../spec/loader";
+import { ViewsTransformer } from "../views";
 
 export async function generate(options: GeneratorOptions) {
   try {
@@ -15,8 +16,9 @@ export async function generate(options: GeneratorOptions) {
     });
 
     const specPath = options.generator.config.spec as string | undefined;
+    let spec = null;
     if (specPath) {
-      const spec = await loadSpec({
+      spec = await loadSpec({
         specPath,
         schemaPath: options.schemaPath,
       });
@@ -52,6 +54,17 @@ export async function generate(options: GeneratorOptions) {
     }
 
     await t.transform();
+
+    if (spec && options.generator.output) {
+      const parsedPath = parseEnvValue(options.generator.output as EnvValue);
+      const viewsOutputPath = path.join(parsedPath, "..", "views");
+      const vt = new ViewsTransformer({
+        models,
+        spec,
+        outputPath: viewsOutputPath,
+      });
+      await vt.transform();
+    }
   } catch (e) {
     console.error(e);
     process.exit(1);

--- a/src/generators/repository/transformer.ts
+++ b/src/generators/repository/transformer.ts
@@ -416,6 +416,109 @@ ${relationSetters.join("\n")}
   }
 
   // =========================================
+  // View methods generation
+  // =========================================
+
+  private generateViewImports(model: ReadonlyDeep<PrismaDMMF.Model>): string {
+    if (!this._spec) return "";
+    const modelViews = this._spec[model.name];
+    if (!modelViews || Object.keys(modelViews).length === 0) return "";
+
+    const modelCamel = changeCase.camelCase(model.name);
+    const allImports: string[] = [];
+
+    for (const viewName of Object.keys(modelViews)) {
+      const viewPascal = changeCase.pascalCase(viewName);
+      allImports.push(
+        `${modelCamel}${viewPascal}Select`,
+        `${model.name}${viewPascal}View`,
+        `${model.name}${viewPascal}Dto`,
+        `to${model.name}${viewPascal}Dto`,
+      );
+    }
+
+    return `import { ${allImports.join(", ")} } from '../views/${model.name}.views';`;
+  }
+
+  private generateViewMethods(model: ReadonlyDeep<PrismaDMMF.Model>): string {
+    if (!this._spec) return "";
+    const modelViews = this._spec[model.name];
+    if (!modelViews || Object.keys(modelViews).length === 0) return "";
+
+    const modelCamel = changeCase.camelCase(model.name);
+    const idFields = this.getIdFields(model);
+    const methods: string[] = [];
+
+    for (const viewName of Object.keys(modelViews)) {
+      const viewPascal = changeCase.pascalCase(viewName);
+      const selectConst = `${modelCamel}${viewPascal}Select`;
+      const viewType = `${model.name}${viewPascal}View`;
+      const dtoType = `${model.name}${viewPascal}Dto`;
+      const mapper = `to${model.name}${viewPascal}Dto`;
+
+      if (idFields.length > 0) {
+        const idField = idFields[0];
+        const idFieldName = changeCase.camelCase(idField.name);
+        const idTsType = this.mapPrismaTypeToTs(idField);
+        methods.push(`
+    async findById${viewPascal}(${idFieldName}: ${idTsType}): Promise<${dtoType} | null> {
+      const record = await this.delegate.findUnique({
+        where: { ${idFieldName} },
+        select: ${selectConst},
+      });
+      return record ? ${mapper}(record as unknown as ${viewType}) : null;
+    }`);
+      }
+
+      methods.push(`
+    async findMany${viewPascal}(args?: { where?: ${model.name}WhereFilter; orderBy?: ${model.name}OrderBy | ${model.name}OrderBy[] }): Promise<${dtoType}[]> {
+      const orderBy = args?.orderBy
+        ? (Array.isArray(args.orderBy)
+            ? args.orderBy.map((o) => ({ [o.field]: o.direction }))
+            : { [args.orderBy.field]: args.orderBy.direction })
+        : undefined;
+      const records = await this.delegate.findMany({
+        where: args?.where as Record<string, any>,
+        orderBy: orderBy as Record<string, any>,
+        select: ${selectConst},
+      });
+      return records.map((r) => ${mapper}(r as unknown as ${viewType}));
+    }`);
+
+      methods.push(`
+    async paginate${viewPascal}(args?: { page?: number; perPage?: number; where?: ${model.name}WhereFilter; orderBy?: ${model.name}OrderBy | ${model.name}OrderBy[] }): Promise<PaginateResult<${dtoType}>> {
+      const page = args?.page ?? 1;
+      const perPage = args?.perPage ?? 20;
+      const skip = (page - 1) * perPage;
+      const orderBy = args?.orderBy
+        ? (Array.isArray(args.orderBy)
+            ? args.orderBy.map((o) => ({ [o.field]: o.direction }))
+            : { [args.orderBy.field]: args.orderBy.direction })
+        : undefined;
+      const [records, total] = await Promise.all([
+        this.delegate.findMany({
+          where: args?.where as Record<string, any>,
+          orderBy: orderBy as Record<string, any>,
+          select: ${selectConst},
+          skip,
+          take: perPage,
+        }),
+        this.delegate.count({ where: args?.where as Record<string, any> }),
+      ]);
+      return {
+        data: records.map((r) => ${mapper}(r as unknown as ${viewType})),
+        total,
+        page,
+        perPage,
+        totalPages: Math.ceil(total / perPage),
+      };
+    }`);
+    }
+
+    return methods.join("\n");
+  }
+
+  // =========================================
   // Full repository file generation
   // =========================================
 
@@ -427,27 +530,23 @@ ${relationSetters.join("\n")}
     const compositeUniques = this.getCompositeUniques(model);
     const enumImports = this.getEnumImports(model);
 
-    // Generate findBy methods for @id fields
     const findByIdMethods = idFields.map((f) =>
       this.generateFindByFieldMethod(model, f),
     );
 
-    // Generate findBy methods for @unique fields
     const findByUniqueMethods = uniqueFields.map((f) =>
       this.generateFindByFieldMethod(model, f),
     );
 
-    // Generate findByXXXAndYYY methods for @@unique composites
     const findByCompositeMethods = compositeUniques.map((c) =>
       this.generateFindByCompositeMethod(model, c),
     );
 
-    // Generate paginate + cursor paginate
     const { typeDefinition: paginateTypes, method: paginateMethod, cursorMethod } =
       this.generatePaginateMethod(model);
 
-    // Generate toModel with relation support
     const toModelMethod = this.generateToModel(model);
+    const viewMethods = this.generateViewMethods(model);
 
     const allMethods = [
       ...findByIdMethods,
@@ -455,17 +554,20 @@ ${relationSetters.join("\n")}
       ...findByCompositeMethods,
       paginateMethod,
       cursorMethod,
+      viewMethods,
     ].join("\n");
 
-    // Build import for enums from @prisma/client
     const enumImportLine = enumImports.length > 0
       ? `import { ${enumImports.map((e) => `${e} as Prisma${e}`).join(", ")} } from '@prisma/client';`
       : "";
+
+    const viewImportLine = this.generateViewImports(model);
 
     return `
       import { ${model.name}Model } from '${this._modelImportPath}/${model.name}.model';
       import { BaseRepository, PaginateResult, CursorPaginateResult, FindOptions } from './BaseRepository';
       ${enumImportLine}
+      ${viewImportLine}
 
       ${paginateTypes}
 

--- a/src/generators/views/index.ts
+++ b/src/generators/views/index.ts
@@ -1,0 +1,1 @@
+export { ViewsTransformer } from "./transformer";

--- a/src/generators/views/transformer.ts
+++ b/src/generators/views/transformer.ts
@@ -1,8 +1,37 @@
 import type { DMMF } from "@prisma/generator-helper";
 import type { ReadonlyDeep } from "../utils/types";
 import { writeFileSafely } from "../utils/writeFileSafely";
-import type { ViewsSpec } from "../../spec/types";
+import type { ViewsSpec, TransformValue, TransformStaticMap } from "../../spec/types";
 import path from "path";
+
+function isStaticMap(v: TransformValue): v is TransformStaticMap {
+  return typeof v === "object" && v !== null;
+}
+
+/**
+ * Derives the base const name for a transform.
+ * viewName="detail", fieldPath="students.attendance"
+ * → "_detailStudentsAttendance"
+ */
+function transformBaseName(viewName: string, fieldPath: string): string {
+  const pathPascal = fieldPath
+    .split(".")
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+    .join("");
+  return `_${viewName}${pathPascal}`;
+}
+
+function generateTransformDecl(
+  viewName: string,
+  fieldPath: string,
+  transform: TransformValue,
+): string {
+  const base = transformBaseName(viewName, fieldPath);
+  if (isStaticMap(transform)) {
+    return `const ${base}Map = ${JSON.stringify(transform)} as const;`;
+  }
+  return `const ${base}Transform = ${transform.toString()};`;
+}
 
 function scalarToTs(field: ReadonlyDeep<DMMF.Field>): string {
   switch (field.type) {
@@ -27,40 +56,56 @@ function scalarToTs(field: ReadonlyDeep<DMMF.Field>): string {
   }
 }
 
-function resolveDtoType(
-  selectVal: unknown,
-  dmmfField: ReadonlyDeep<DMMF.Field> | undefined,
-  models: ReadonlyDeep<DMMF.Model[]>,
-): string {
-  if (!dmmfField) return "unknown";
-
-  if (selectVal === true) {
-    const base = scalarToTs(dmmfField);
-    const nullable = !dmmfField.isRequired ? " | null" : "";
-    return dmmfField.isList ? `Array<${base}>${nullable}` : `${base}${nullable}`;
-  }
-
-  if (typeof selectVal === "object" && selectVal !== null && "select" in selectVal) {
-    const nestedSelect = (selectVal as { select: Record<string, unknown> }).select;
-    const relatedModel = models.find((m) => m.name === dmmfField.type);
-    if (!relatedModel) return "unknown";
-    const shape = buildDtoShape(nestedSelect, relatedModel, models);
-    const nullable = !dmmfField.isRequired ? " | null" : "";
-    return dmmfField.isList ? `Array<${shape}>${nullable}` : `${shape}${nullable}`;
-  }
-
-  return "unknown";
-}
-
 function buildDtoShape(
   select: Record<string, unknown>,
   model: ReadonlyDeep<DMMF.Model>,
   models: ReadonlyDeep<DMMF.Model[]>,
+  viewName: string,
+  transforms: Record<string, TransformValue>,
+  pathPrefix: string,
 ): string {
   const fields = Object.entries(select).map(([key, val]) => {
+    const currentPath = pathPrefix ? `${pathPrefix}.${key}` : key;
     const dmmfField = model.fields.find((f) => f.name === key);
-    const type = resolveDtoType(val, dmmfField, models);
-    return `${key}: ${type}`;
+    const transform = transforms[currentPath];
+
+    if (val === true) {
+      if (transform) {
+        const base = transformBaseName(viewName, currentPath);
+        const nullable = dmmfField && !dmmfField.isRequired ? " | null" : "";
+        if (isStaticMap(transform)) {
+          const union = Object.values(transform)
+            .map((v) => JSON.stringify(v))
+            .join(" | ");
+          return `${key}: ${union}${nullable}`;
+        }
+        return `${key}: ReturnType<typeof ${base}Transform>${nullable}`;
+      }
+      if (!dmmfField) return `${key}: unknown`;
+      const base = scalarToTs(dmmfField);
+      const nullable = !dmmfField.isRequired ? " | null" : "";
+      return `${key}: ${dmmfField.isList ? `Array<${base}>` : base}${nullable}`;
+    }
+
+    if (typeof val === "object" && val !== null && "select" in val) {
+      const nestedSelect = (val as { select: Record<string, unknown> }).select;
+      const relatedModel = models.find((m) => m.name === dmmfField?.type);
+      if (!relatedModel || !dmmfField) return `${key}: unknown`;
+      const shape = buildDtoShape(
+        nestedSelect,
+        relatedModel,
+        models,
+        viewName,
+        transforms,
+        currentPath,
+      );
+      const nullable = !dmmfField.isRequired ? " | null" : "";
+      return dmmfField.isList
+        ? `${key}: Array<${shape}>${nullable}`
+        : `${key}: ${shape}${nullable}`;
+    }
+
+    return `${key}: unknown`;
   });
   return `{ ${fields.join("; ")} }`;
 }
@@ -85,10 +130,16 @@ function buildMapperBody(
   select: Record<string, unknown>,
   model: ReadonlyDeep<DMMF.Model>,
   models: ReadonlyDeep<DMMF.Model[]>,
+  viewName: string,
+  transforms: Record<string, TransformValue>,
   varName: string,
+  pathPrefix: string,
 ): string {
   const fields = Object.entries(select).map(([key, val]) => {
+    const currentPath = pathPrefix ? `${pathPrefix}.${key}` : key;
     const dmmfField = model.fields.find((f) => f.name === key);
+    const transform = transforms[currentPath];
+
     if (
       typeof val === "object" &&
       val !== null &&
@@ -102,11 +153,23 @@ function buildMapperBody(
           nestedSelect,
           relatedModel,
           models,
+          viewName,
+          transforms,
           "item",
+          currentPath,
         );
         return `${key}: ${varName}.${key}.map((item) => (${innerBody}))`;
       }
     }
+
+    if (transform) {
+      const base = transformBaseName(viewName, currentPath);
+      if (isStaticMap(transform)) {
+        return `${key}: ${base}Map[${varName}.${key} as keyof typeof ${base}Map]`;
+      }
+      return `${key}: ${base}Transform(${varName}.${key})`;
+    }
+
     return `${key}: ${varName}.${key}`;
   });
   return `{ ${fields.join(", ")} }`;
@@ -165,31 +228,49 @@ export function defineViews<T extends TypedViewsSpec>(spec: T): T {
     modelViews: ViewsSpec[string],
     dmmfModel: ReadonlyDeep<DMMF.Model>,
   ) {
-    const blocks: string[] = [
-      `import type { Prisma } from "@prisma/client";`,
-      "",
-    ];
+    const blocks: string[] = [`import type { Prisma } from "@prisma/client";`, ""];
+
+    // Emit transform consts (grouped before all view blocks)
+    const transformDecls: string[] = [];
+    for (const [viewName, viewSpec] of Object.entries(modelViews)) {
+      if (viewSpec.transforms) {
+        for (const [fieldPath, transform] of Object.entries(viewSpec.transforms)) {
+          transformDecls.push(generateTransformDecl(viewName, fieldPath, transform));
+        }
+      }
+    }
+    if (transformDecls.length > 0) {
+      blocks.push(...transformDecls, "");
+    }
 
     for (const [viewName, viewSpec] of Object.entries(modelViews)) {
-      const viewCapitalized = viewName.charAt(0).toUpperCase() + viewName.slice(1);
+      const viewCapitalized =
+        viewName.charAt(0).toUpperCase() + viewName.slice(1);
       const selectConstName = `${modelName.charAt(0).toLowerCase()}${modelName.slice(1)}${viewCapitalized}Select`;
       const viewTypeName = `${modelName}${viewCapitalized}View`;
       const dtoTypeName = `${modelName}${viewCapitalized}Dto`;
       const mapperName = `to${modelName}${viewCapitalized}Dto`;
 
+      const transforms = viewSpec.transforms ?? {};
       const serializedSelect = serializeSelectValue(viewSpec.select, 0);
 
       const dtoShape = buildDtoShape(
         viewSpec.select as Record<string, unknown>,
         dmmfModel,
         this._models,
+        viewName,
+        transforms,
+        "",
       );
 
       const mapperBody = buildMapperBody(
         viewSpec.select as Record<string, unknown>,
         dmmfModel,
         this._models,
+        viewName,
+        transforms,
         "v",
+        "",
       );
 
       blocks.push(

--- a/src/generators/views/transformer.ts
+++ b/src/generators/views/transformer.ts
@@ -1,0 +1,217 @@
+import type { DMMF } from "@prisma/generator-helper";
+import type { ReadonlyDeep } from "../utils/types";
+import { writeFileSafely } from "../utils/writeFileSafely";
+import type { ViewsSpec } from "../../spec/types";
+import path from "path";
+
+function scalarToTs(field: ReadonlyDeep<DMMF.Field>): string {
+  switch (field.type) {
+    case "String":
+      return "string";
+    case "Int":
+    case "Float":
+    case "Decimal":
+      return "number";
+    case "Boolean":
+      return "boolean";
+    case "DateTime":
+      return "Date";
+    case "BigInt":
+      return "bigint";
+    case "Bytes":
+      return "Uint8Array";
+    case "Json":
+      return "unknown";
+    default:
+      return "string";
+  }
+}
+
+function resolveDtoType(
+  selectVal: unknown,
+  dmmfField: ReadonlyDeep<DMMF.Field> | undefined,
+  models: ReadonlyDeep<DMMF.Model[]>,
+): string {
+  if (!dmmfField) return "unknown";
+
+  if (selectVal === true) {
+    const base = scalarToTs(dmmfField);
+    const nullable = !dmmfField.isRequired ? " | null" : "";
+    return dmmfField.isList ? `Array<${base}>${nullable}` : `${base}${nullable}`;
+  }
+
+  if (typeof selectVal === "object" && selectVal !== null && "select" in selectVal) {
+    const nestedSelect = (selectVal as { select: Record<string, unknown> }).select;
+    const relatedModel = models.find((m) => m.name === dmmfField.type);
+    if (!relatedModel) return "unknown";
+    const shape = buildDtoShape(nestedSelect, relatedModel, models);
+    const nullable = !dmmfField.isRequired ? " | null" : "";
+    return dmmfField.isList ? `Array<${shape}>${nullable}` : `${shape}${nullable}`;
+  }
+
+  return "unknown";
+}
+
+function buildDtoShape(
+  select: Record<string, unknown>,
+  model: ReadonlyDeep<DMMF.Model>,
+  models: ReadonlyDeep<DMMF.Model[]>,
+): string {
+  const fields = Object.entries(select).map(([key, val]) => {
+    const dmmfField = model.fields.find((f) => f.name === key);
+    const type = resolveDtoType(val, dmmfField, models);
+    return `${key}: ${type}`;
+  });
+  return `{ ${fields.join("; ")} }`;
+}
+
+function serializeSelectValue(val: unknown, indent: number): string {
+  if (val === true) return "true";
+  if (val === false) return "false";
+  if (typeof val === "string") return JSON.stringify(val);
+  if (typeof val === "number") return String(val);
+  if (typeof val === "object" && val !== null) {
+    const obj = val as Record<string, unknown>;
+    const pad = "  ".repeat(indent);
+    const inner = Object.entries(obj)
+      .map(([k, v]) => `${pad}  ${k}: ${serializeSelectValue(v, indent + 1)}`)
+      .join(",\n");
+    return `{\n${inner},\n${pad}}`;
+  }
+  return JSON.stringify(val);
+}
+
+function buildMapperBody(
+  select: Record<string, unknown>,
+  model: ReadonlyDeep<DMMF.Model>,
+  models: ReadonlyDeep<DMMF.Model[]>,
+  varName: string,
+): string {
+  const fields = Object.entries(select).map(([key, val]) => {
+    const dmmfField = model.fields.find((f) => f.name === key);
+    if (
+      typeof val === "object" &&
+      val !== null &&
+      "select" in val &&
+      dmmfField?.isList
+    ) {
+      const nestedSelect = (val as { select: Record<string, unknown> }).select;
+      const relatedModel = models.find((m) => m.name === dmmfField.type);
+      if (relatedModel) {
+        const innerBody = buildMapperBody(
+          nestedSelect,
+          relatedModel,
+          models,
+          "item",
+        );
+        return `${key}: ${varName}.${key}.map((item) => (${innerBody}))`;
+      }
+    }
+    return `${key}: ${varName}.${key}`;
+  });
+  return `{ ${fields.join(", ")} }`;
+}
+
+export class ViewsTransformer {
+  private readonly _models: ReadonlyDeep<DMMF.Model[]>;
+  private readonly _spec: ViewsSpec;
+  private _outputPath: string;
+
+  constructor(args: {
+    models: ReadonlyDeep<DMMF.Model[]>;
+    spec: ViewsSpec;
+    outputPath: string;
+  }) {
+    this._models = args.models;
+    this._spec = args.spec;
+    this._outputPath = args.outputPath;
+  }
+
+  async transform() {
+    await this.generateSpecFile();
+
+    for (const [modelName, modelViews] of Object.entries(this._spec)) {
+      const dmmfModel = this._models.find((m) => m.name === modelName);
+      if (!dmmfModel) continue;
+      await this.generateModelViewsFile(modelName, modelViews, dmmfModel);
+    }
+  }
+
+  private async generateSpecFile() {
+    const modelEntries = this._models
+      .map((m) => {
+        return `  ${m.name}?: { [view: string]: { select: Prisma.${m.name}Select } };`;
+      })
+      .join("\n");
+
+    const content = `
+import type { Prisma } from "@prisma/client";
+
+type TypedViewsSpec = {
+${modelEntries}
+};
+
+export function defineViews<T extends TypedViewsSpec>(spec: T): T {
+  return spec;
+}
+`;
+
+    const filePath = path.join(this._outputPath, "spec.ts");
+    await writeFileSafely(filePath, content, false);
+  }
+
+  private async generateModelViewsFile(
+    modelName: string,
+    modelViews: ViewsSpec[string],
+    dmmfModel: ReadonlyDeep<DMMF.Model>,
+  ) {
+    const blocks: string[] = [
+      `import type { Prisma } from "@prisma/client";`,
+      "",
+    ];
+
+    for (const [viewName, viewSpec] of Object.entries(modelViews)) {
+      const viewCapitalized = viewName.charAt(0).toUpperCase() + viewName.slice(1);
+      const selectConstName = `${modelName.charAt(0).toLowerCase()}${modelName.slice(1)}${viewCapitalized}Select`;
+      const viewTypeName = `${modelName}${viewCapitalized}View`;
+      const dtoTypeName = `${modelName}${viewCapitalized}Dto`;
+      const mapperName = `to${modelName}${viewCapitalized}Dto`;
+
+      const serializedSelect = serializeSelectValue(viewSpec.select, 0);
+
+      const dtoShape = buildDtoShape(
+        viewSpec.select as Record<string, unknown>,
+        dmmfModel,
+        this._models,
+      );
+
+      const mapperBody = buildMapperBody(
+        viewSpec.select as Record<string, unknown>,
+        dmmfModel,
+        this._models,
+        "v",
+      );
+
+      blocks.push(
+        `// --- ${viewName} view ---`,
+        "",
+        `export const ${selectConstName} = ${serializedSelect} as const satisfies Prisma.${modelName}Select;`,
+        "",
+        `export type ${viewTypeName} = Prisma.${modelName}GetPayload<{`,
+        `  select: typeof ${selectConstName};`,
+        `}>;`,
+        "",
+        `export type ${dtoTypeName} = ${dtoShape};`,
+        "",
+        `export function ${mapperName}(v: ${viewTypeName}): ${dtoTypeName} {`,
+        `  return ${mapperBody};`,
+        `}`,
+        "",
+      );
+    }
+
+    const content = blocks.join("\n");
+    const filePath = path.join(this._outputPath, `${modelName}.views.ts`);
+    await writeFileSafely(filePath, content, false);
+  }
+}

--- a/src/spec/index.ts
+++ b/src/spec/index.ts
@@ -6,4 +6,7 @@ export type {
   ViewsSpec,
   ViewSpec,
   ViewSpecSelect,
+  TransformFn,
+  TransformStaticMap,
+  TransformValue,
 } from "./types";

--- a/src/spec/types.ts
+++ b/src/spec/types.ts
@@ -2,17 +2,32 @@
  * View-driven DTO generation spec types.
  *
  * A spec file describes named "views" per Prisma model. Each view declares a
- * Prisma `select` shape that the generator will use to emit a view type, a DTO
- * type, and a mapper/repository methods for that view.
- *
- * Later phases extend {@link ViewSpec} with `transforms`, `computed`, and `raw`
- * escape hatches. Phase 1 only consumes `select`.
+ * Prisma `select` shape plus optional `transforms` that the generator uses to
+ * emit a view type, a DTO type, and a mapper/repository methods for that view.
  */
 
 export type ViewSpecSelect = Record<string, unknown>;
 
+/** Function transform: receives the raw DB value, returns the DTO value. */
+
+export type TransformFn = (v: any) => unknown;
+
+/**
+ * Static map transform — sugar for simple enum→label mappings.
+ * e.g. `{ ABSENT: "お休み", SCHEDULED: "予定" }`
+ */
+export type TransformStaticMap = Record<string, string>;
+
+export type TransformValue = TransformFn | TransformStaticMap;
+
 export type ViewSpec = {
   select: ViewSpecSelect;
+  /**
+   * Field-level transforms keyed by dot-path relative to the view root.
+   * e.g. `"students.attendance"` transforms the `attendance` field inside each
+   * element of the `students` array.
+   */
+  transforms?: Record<string, TransformValue>;
 };
 
 export type ModelViewsSpec = {

--- a/tests/repositoryTransformer.test.ts
+++ b/tests/repositoryTransformer.test.ts
@@ -379,4 +379,125 @@ describe("Repository Transformer", () => {
       expect(content).toContain("...options");
     });
   });
+
+  describe("transform — view methods (spec)", () => {
+    const userModel = makeModel("User", [
+      makeField({ name: "id", type: "Int", isId: true }),
+      makeField({ name: "email", type: "String" }),
+      makeField({ name: "name", type: "String", isRequired: false }),
+    ]);
+
+    const spec = {
+      User: {
+        profile: {
+          select: { id: true, email: true, name: true },
+        },
+      },
+    };
+
+    it("generates findByIdProfile / findManyProfile / paginateProfile", async () => {
+      const t = new RepositoryTransformer({
+        models: [userModel],
+        outputPath: "/tmp/test-repo",
+        modelImportPath: "../model",
+      });
+      t.setSpec({ spec });
+      await t.transform();
+
+      const content = mockedWriteFileSafely.mock.calls[0][1] as string;
+      expect(content).toContain("async findByIdProfile(");
+      expect(content).toContain("async findManyProfile(");
+      expect(content).toContain("async paginateProfile(");
+    });
+
+    it("imports view symbols from ../views/User.views", async () => {
+      const t = new RepositoryTransformer({
+        models: [userModel],
+        outputPath: "/tmp/test-repo",
+        modelImportPath: "../model",
+      });
+      t.setSpec({ spec });
+      await t.transform();
+
+      const content = mockedWriteFileSafely.mock.calls[0][1] as string;
+      expect(content).toContain("from '../views/User.views'");
+      expect(content).toContain("userProfileSelect");
+      expect(content).toContain("UserProfileView");
+      expect(content).toContain("UserProfileDto");
+      expect(content).toContain("toUserProfileDto");
+    });
+
+    it("findByIdProfile uses select const and mapper", async () => {
+      const t = new RepositoryTransformer({
+        models: [userModel],
+        outputPath: "/tmp/test-repo",
+        modelImportPath: "../model",
+      });
+      t.setSpec({ spec });
+      await t.transform();
+
+      const content = mockedWriteFileSafely.mock.calls[0][1] as string;
+      expect(content).toContain("select: userProfileSelect");
+      expect(content).toContain("toUserProfileDto(");
+      expect(content).toContain("Promise<UserProfileDto | null>");
+    });
+
+    it("paginateProfile returns PaginateResult<UserProfileDto>", async () => {
+      const t = new RepositoryTransformer({
+        models: [userModel],
+        outputPath: "/tmp/test-repo",
+        modelImportPath: "../model",
+      });
+      t.setSpec({ spec });
+      await t.transform();
+
+      const content = mockedWriteFileSafely.mock.calls[0][1] as string;
+      expect(content).toContain("Promise<PaginateResult<UserProfileDto>>");
+      expect(content).toContain("totalPages: Math.ceil(total / perPage)");
+    });
+
+    it("generates no view methods when spec has no entry for model", async () => {
+      const postModel = makeModel("Post", [
+        makeField({ name: "id", type: "Int", isId: true }),
+        makeField({ name: "title", type: "String" }),
+      ]);
+
+      const t = new RepositoryTransformer({
+        models: [postModel],
+        outputPath: "/tmp/test-repo",
+        modelImportPath: "../model",
+      });
+      t.setSpec({ spec });
+      await t.transform();
+
+      const content = mockedWriteFileSafely.mock.calls[0][1] as string;
+      expect(content).not.toContain("findByIdProfile");
+      expect(content).not.toContain("from '../views/");
+    });
+
+    it("generates methods for multiple views", async () => {
+      const multiSpec = {
+        User: {
+          profile: { select: { id: true, name: true } },
+          list: { select: { id: true, email: true } },
+        },
+      };
+
+      const t = new RepositoryTransformer({
+        models: [userModel],
+        outputPath: "/tmp/test-repo",
+        modelImportPath: "../model",
+      });
+      t.setSpec({ spec: multiSpec });
+      await t.transform();
+
+      const content = mockedWriteFileSafely.mock.calls[0][1] as string;
+      expect(content).toContain("findByIdProfile");
+      expect(content).toContain("findManyProfile");
+      expect(content).toContain("paginateProfile");
+      expect(content).toContain("findByIdList");
+      expect(content).toContain("findManyList");
+      expect(content).toContain("paginateList");
+    });
+  });
 });

--- a/tests/viewsTransformer.test.ts
+++ b/tests/viewsTransformer.test.ts
@@ -236,3 +236,275 @@ describe("ViewsTransformer", () => {
     expect(content).toContain("UserListItemView");
   });
 });
+
+// ─── Phase 2: transforms ────────────────────────────────────────────────────
+
+const lessonStudentFields = [
+  makeField({ name: "id", type: "Int", isId: true }),
+  makeField({ name: "attendance", type: "String" }),
+  makeField({ name: "note", type: "String", isRequired: false }),
+];
+
+const lessonFields = [
+  makeField({ name: "id", type: "Int", isId: true }),
+  makeField({ name: "date", type: "String" }),
+  makeField({ name: "status", type: "String" }),
+  makeField({
+    name: "students",
+    type: "LessonStudent",
+    kind: "object",
+    isList: true,
+    isRequired: true,
+    relationName: "LessonStudents",
+  } as any),
+];
+
+const lessonStudentModel = makeModel("LessonStudent", lessonStudentFields);
+const lessonModel = makeModel("Lesson", lessonFields);
+
+describe("ViewsTransformer — Phase 2 transforms", () => {
+  beforeEach(() => {
+    mockedWriteFileSafely.mockClear();
+  });
+
+  it("static map: emits map const before view blocks", async () => {
+    const vt = new ViewsTransformer({
+      models: [lessonModel, lessonStudentModel],
+      spec: {
+        Lesson: {
+          detail: {
+            select: { id: true, status: true },
+            transforms: {
+              status: { ACTIVE: "開催中", CANCELLED: "中止" },
+            },
+          },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("Lesson.views.ts");
+    expect(content).toContain("_detailStatusMap");
+    expect(content).toContain('"ACTIVE":"開催中"');
+    expect(content).toContain("as const");
+  });
+
+  it("static map: DTO type uses literal union of map values", async () => {
+    const vt = new ViewsTransformer({
+      models: [lessonModel, lessonStudentModel],
+      spec: {
+        Lesson: {
+          detail: {
+            select: { id: true, status: true },
+            transforms: {
+              status: { ACTIVE: "開催中", CANCELLED: "中止" },
+            },
+          },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("Lesson.views.ts");
+    expect(content).toContain('"開催中" | "中止"');
+    // original string type should not appear for that field
+    expect(content).not.toMatch(/status: string/);
+  });
+
+  it("static map: mapper uses map lookup", async () => {
+    const vt = new ViewsTransformer({
+      models: [lessonModel, lessonStudentModel],
+      spec: {
+        Lesson: {
+          detail: {
+            select: { id: true, status: true },
+            transforms: {
+              status: { ACTIVE: "開催中", CANCELLED: "中止" },
+            },
+          },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("Lesson.views.ts");
+    expect(content).toContain("_detailStatusMap[v.status as keyof typeof _detailStatusMap]");
+  });
+
+  it("function transform: emits transform const", async () => {
+    const vt = new ViewsTransformer({
+      models: [lessonModel, lessonStudentModel],
+      spec: {
+        Lesson: {
+          detail: {
+            select: { id: true, status: true },
+            transforms: {
+              status: (v: string) => (v === "CANCELLED" ? "中止" : "開催中"),
+            },
+          },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("Lesson.views.ts");
+    expect(content).toContain("_detailStatusTransform");
+    expect(content).toContain("中止");
+  });
+
+  it("function transform: DTO type uses ReturnType", async () => {
+    const vt = new ViewsTransformer({
+      models: [lessonModel, lessonStudentModel],
+      spec: {
+        Lesson: {
+          detail: {
+            select: { id: true, status: true },
+            transforms: {
+              status: (v: string) => (v === "CANCELLED" ? "中止" : "開催中"),
+            },
+          },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("Lesson.views.ts");
+    expect(content).toContain("ReturnType<typeof _detailStatusTransform>");
+  });
+
+  it("function transform: mapper calls transform function", async () => {
+    const vt = new ViewsTransformer({
+      models: [lessonModel, lessonStudentModel],
+      spec: {
+        Lesson: {
+          detail: {
+            select: { id: true, status: true },
+            transforms: {
+              status: (v: string) => (v === "CANCELLED" ? "中止" : "開催中"),
+            },
+          },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("Lesson.views.ts");
+    expect(content).toContain("_detailStatusTransform(v.status)");
+  });
+
+  it("nested path: static map transforms field inside array relation", async () => {
+    const vt = new ViewsTransformer({
+      models: [lessonModel, lessonStudentModel],
+      spec: {
+        Lesson: {
+          detail: {
+            select: {
+              id: true,
+              students: {
+                select: { id: true, attendance: true },
+              },
+            },
+            transforms: {
+              "students.attendance": { ABSENT: "お休み", SCHEDULED: "予定" },
+            },
+          },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("Lesson.views.ts");
+    // Map const emitted
+    expect(content).toContain("_detailStudentsAttendanceMap");
+    // DTO type has literal union
+    expect(content).toContain('"お休み" | "予定"');
+    // Mapper uses map lookup inside .map()
+    expect(content).toContain(
+      "_detailStudentsAttendanceMap[item.attendance as keyof typeof _detailStudentsAttendanceMap]",
+    );
+  });
+
+  it("nested path: function transform transforms field inside array relation", async () => {
+    const vt = new ViewsTransformer({
+      models: [lessonModel, lessonStudentModel],
+      spec: {
+        Lesson: {
+          detail: {
+            select: {
+              id: true,
+              students: {
+                select: { id: true, attendance: true },
+              },
+            },
+            transforms: {
+              "students.attendance": (v: string) =>
+                v === "ABSENT" ? "お休み" : "予定",
+            },
+          },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("Lesson.views.ts");
+    expect(content).toContain("_detailStudentsAttendanceTransform");
+    expect(content).toContain("ReturnType<typeof _detailStudentsAttendanceTransform>");
+    expect(content).toContain("_detailStudentsAttendanceTransform(item.attendance)");
+  });
+
+  it("untransformed fields alongside transformed fields remain unchanged", async () => {
+    const vt = new ViewsTransformer({
+      models: [lessonModel, lessonStudentModel],
+      spec: {
+        Lesson: {
+          detail: {
+            select: { id: true, date: true, status: true },
+            transforms: {
+              status: { ACTIVE: "開催中", CANCELLED: "中止" },
+            },
+          },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("Lesson.views.ts");
+    expect(content).toContain("id: number");
+    expect(content).toContain("date: string");
+    expect(content).toContain("v.id");
+    expect(content).toContain("v.date");
+  });
+
+  it("two views with same path but different transforms get distinct consts", async () => {
+    const vt = new ViewsTransformer({
+      models: [lessonModel, lessonStudentModel],
+      spec: {
+        Lesson: {
+          detail: {
+            select: { id: true, status: true },
+            transforms: { status: { ACTIVE: "開催中" } },
+          },
+          listItem: {
+            select: { id: true, status: true },
+            transforms: { status: { ACTIVE: "active" } },
+          },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("Lesson.views.ts");
+    expect(content).toContain("_detailStatusMap");
+    expect(content).toContain("_listItemStatusMap");
+  });
+});

--- a/tests/viewsTransformer.test.ts
+++ b/tests/viewsTransformer.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { DMMF as PrismaDMMF } from "@prisma/generator-helper";
+
+vi.mock("../src/generators/utils/writeFileSafely", () => ({
+  writeFileSafely: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { ViewsTransformer } from "../src/generators/views";
+import { writeFileSafely } from "../src/generators/utils/writeFileSafely";
+
+const mockedWriteFileSafely = vi.mocked(writeFileSafely);
+
+const makeField = (
+  overrides: Partial<PrismaDMMF.Field> & { name: string; type: string },
+): PrismaDMMF.Field =>
+  ({
+    kind: "scalar",
+    isList: false,
+    isRequired: true,
+    isUnique: false,
+    isId: false,
+    isReadOnly: false,
+    hasDefaultValue: false,
+    isGenerated: false,
+    isUpdatedAt: false,
+    ...overrides,
+  }) as PrismaDMMF.Field;
+
+const makeModel = (
+  name: string,
+  fields: PrismaDMMF.Field[],
+  overrides: Partial<PrismaDMMF.Model> = {},
+): PrismaDMMF.Model =>
+  ({
+    name,
+    dbName: null,
+    fields,
+    primaryKey: null,
+    uniqueFields: [],
+    uniqueIndexes: [],
+    isGenerated: false,
+    ...overrides,
+  }) as PrismaDMMF.Model;
+
+function findContent(filename: string): string {
+  const call = mockedWriteFileSafely.mock.calls.find(([p]) =>
+    (p as string).endsWith(filename),
+  );
+  if (!call) throw new Error(`No generated file found for ${filename}`);
+  return call[1] as string;
+}
+
+const postFields = [
+  makeField({ name: "id", type: "Int", isId: true }),
+  makeField({ name: "title", type: "String" }),
+  makeField({ name: "published", type: "Boolean" }),
+];
+
+const userFields = [
+  makeField({ name: "id", type: "Int", isId: true }),
+  makeField({ name: "email", type: "String" }),
+  makeField({ name: "name", type: "String", isRequired: false }),
+  makeField({
+    name: "posts",
+    type: "Post",
+    kind: "object",
+    isList: true,
+    isRequired: true,
+    relationName: "UserPosts",
+  } as any),
+];
+
+const postModel = makeModel("Post", postFields);
+const userModel = makeModel("User", userFields);
+
+describe("ViewsTransformer", () => {
+  beforeEach(() => {
+    mockedWriteFileSafely.mockClear();
+  });
+
+  it("generates spec.ts with TypedViewsSpec + typed defineViews", async () => {
+    const vt = new ViewsTransformer({
+      models: [userModel, postModel],
+      spec: {
+        User: {
+          listItem: { select: { id: true, email: true } },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const spec = findContent("spec.ts");
+    expect(spec).toContain("TypedViewsSpec");
+    expect(spec).toContain("Prisma.UserSelect");
+    expect(spec).toContain("Prisma.PostSelect");
+    expect(spec).toContain("export function defineViews");
+  });
+
+  it("generates <Model>.views.ts with Select const", async () => {
+    const vt = new ViewsTransformer({
+      models: [userModel, postModel],
+      spec: {
+        User: {
+          listItem: { select: { id: true, email: true, name: true } },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("User.views.ts");
+    expect(content).toContain("userListItemSelect");
+    expect(content).toContain("as const satisfies Prisma.UserSelect");
+    expect(content).toContain("id: true");
+    expect(content).toContain("email: true");
+  });
+
+  it("generates View type using GetPayload", async () => {
+    const vt = new ViewsTransformer({
+      models: [userModel, postModel],
+      spec: {
+        User: {
+          listItem: { select: { id: true, email: true } },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("User.views.ts");
+    expect(content).toContain("UserListItemView");
+    expect(content).toContain("Prisma.UserGetPayload");
+    expect(content).toContain("typeof userListItemSelect");
+  });
+
+  it("generates Dto type with correct scalar types", async () => {
+    const vt = new ViewsTransformer({
+      models: [userModel, postModel],
+      spec: {
+        User: {
+          listItem: { select: { id: true, email: true, name: true } },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("User.views.ts");
+    expect(content).toContain("UserListItemDto");
+    expect(content).toContain("id: number");
+    expect(content).toContain("email: string");
+    expect(content).toContain("name: string | null");
+  });
+
+  it("generates mapper function", async () => {
+    const vt = new ViewsTransformer({
+      models: [userModel, postModel],
+      spec: {
+        User: {
+          listItem: { select: { id: true, email: true } },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("User.views.ts");
+    expect(content).toContain("toUserListItemDto");
+    expect(content).toContain("(v: UserListItemView): UserListItemDto");
+    expect(content).toContain("v.id");
+    expect(content).toContain("v.email");
+  });
+
+  it("handles nested select (relation field)", async () => {
+    const vt = new ViewsTransformer({
+      models: [userModel, postModel],
+      spec: {
+        User: {
+          profile: {
+            select: {
+              id: true,
+              email: true,
+              posts: {
+                select: { id: true, title: true, published: true },
+              },
+            },
+          },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("User.views.ts");
+    // Dto should have nested array type
+    expect(content).toContain("Array<");
+    expect(content).toContain("id: number");
+    expect(content).toContain("title: string");
+    expect(content).toContain("published: boolean");
+  });
+
+  it("handles nullable fields with | null", async () => {
+    const vt = new ViewsTransformer({
+      models: [userModel, postModel],
+      spec: {
+        User: {
+          profile: { select: { id: true, name: true } },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("User.views.ts");
+    expect(content).toContain("name: string | null");
+  });
+
+  it("generates files for multiple views per model", async () => {
+    const vt = new ViewsTransformer({
+      models: [userModel, postModel],
+      spec: {
+        User: {
+          profile: { select: { id: true, email: true } },
+          listItem: { select: { id: true } },
+        },
+      },
+      outputPath: "/tmp/views",
+    });
+    await vt.transform();
+
+    const content = findContent("User.views.ts");
+    expect(content).toContain("userProfileSelect");
+    expect(content).toContain("userListItemSelect");
+    expect(content).toContain("UserProfileView");
+    expect(content).toContain("UserListItemView");
+  });
+});

--- a/tsconfig.generated.json
+++ b/tsconfig.generated.json
@@ -17,6 +17,7 @@
   },
   "include": [
     "./prisma/dto.spec.ts",
-    "./prisma/__generated__/**/*.ts"
+    "./prisma/__generated__/**/*.ts",
+    "./prisma/__generated__/views/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Summary

- `ViewSpec.transforms` 追加: dot-path キーでフィールド変換を宣言
- Static map `{ ABSENT: "お休み" }` → literal union DTO型 + mapルックアップ生成
- Function `(v) => ...` → `ReturnType<typeof fn>` DTO型 + 関数呼び出し生成
- ネストパス `"students.attendance"` → array `.map()` 内で適用
- `TransformFn`, `TransformStaticMap`, `TransformValue` を `spec` パッケージから公開
- Phase 2テスト 10件追加 (全88件通過)

## Test plan

- [x] `npx vitest run` — 88 tests pass
- [x] static map: DTO型がリテラルユニオン、mapper がマップルックアップ
- [x] function transform: DTO型が `ReturnType<>`, mapper が関数呼び出し
- [x] nested path `"students.attendance"`: `.map()` 内で正しく適用
- [x] 異なる view 同一パスが別々の const 名を持つ
- [x] transform なしフィールドは既存挙動そのまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)