### PR TITLE
feat(views): Phase 4-6 — annotation, raw escape, DX improvements

### DIFF
--- a/docs/next-plan.md
+++ b/docs/next-plan.md
@@ -266,46 +266,45 @@ spec の view 内で当該フィールドに触ると annotation 適用済み型
 
 ## 実装フェーズ
 
-### Phase 1 — spec DSL core (MVP)
+### Phase 1 — spec DSL core (MVP) ✅
 
-- [ ] `defineViews` ランタイム(薄いパススルー関数)
-- [ ] Prisma generator block で `spec` オプション受付
-- [ ] spec ファイルを `jiti` 等で読込
-- [ ] 静的 select のみ対応(transform/computed なし)
-- [ ] `<Model>.views.ts` に `<view>Select`, `<view>View`, `<view>Dto`, `to<View>Dto` 生成
-- [ ] Repository への `findById{View}` / `findMany{View}` / `paginate{View}` 自動追加
-- [ ] 既存 v7 生成物と共存(default model/repo はそのまま)
+- [x] `defineViews` ランタイム(薄いパススルー関数)
+- [x] Prisma generator block で `spec` オプション受付
+- [x] spec ファイルを `jiti` 等で読込
+- [x] 静的 select のみ対応(transform/computed なし)
+- [x] `<Model>.views.ts` に `<view>Select`, `<view>View`, `<view>Dto`, `to<View>Dto` 生成
+- [x] Repository への `findById{View}` / `findMany{View}` / `paginate{View}` 自動追加
+- [x] 既存 v7 生成物と共存(default model/repo はそのまま)
 
-### Phase 2 — transforms
+### Phase 2 — transforms ✅
 
-- [ ] `transforms: { 'path.to.field': (v) => ... }` 対応
-- [ ] パス指定でネスト relation のフィールドも変換可能
-- [ ] transform 適用後の DTO 型を推論(戻り値型から)
-- [ ] 静的マップ糖衣: `transforms: { 'students.attendance': { ABSENT: 'お休み', SCHEDULED: '予定' } }`
+- [x] `transforms: { 'path.to.field': (v) => ... }` 対応
+- [x] パス指定でネスト relation のフィールドも変換可能
+- [x] transform 適用後の DTO 型を推論(戻り値型から)
+- [x] 静的マップ糖衣: `transforms: { 'students.attendance': { ABSENT: 'お休み', SCHEDULED: '予定' } }`
 
-### Phase 3 — computed
+### Phase 3 — computed ✅
 
-- [ ] `computed: { name: { type, from } }` 対応
-- [ ] `type` で TS 型指定、`from(row)` で値計算
-- [ ] 非同期 computed は非対応(パフォーマンス制御不能のため)
+- [x] `computed: { name: { type, from } }` 対応
+- [x] `type` で TS 型指定、`from(row)` で値計算
+- [x] 非同期 computed は非対応(パフォーマンス制御不能のため)
 
-### Phase 4 — annotation 拡張
+### Phase 4 — annotation 拡張 ✅
 
-- [ ] `@dto.hide` — DTO から除外
-- [ ] `@dto.map(enumName, mapping)` — enum→label 宣言的マップ
-- [ ] spec より弱い優先度で適用
+- [x] `@dto.hide` — DTO から除外
+- [x] `@dto.map({ KEY: "label" })` — enum→label 宣言的マップ
+- [x] spec より弱い優先度で適用
 
-### Phase 5 — raw エスケープ
+### Phase 5 — raw エスケープ ✅
 
-- [ ] `raw: (prisma, args) => Promise<...>` + `map: (row) => Dto` 対応
-- [ ] 型は戻り値推論、Repo メソッドとして統一化
+- [x] `raw: (prisma, args) => Promise<...>` + `map: (row) => Dto` 対応
+- [x] 型は戻り値推論、Repo メソッドとして統一化
 
-### Phase 6 — DX
+### Phase 6 — DX ✅
 
-- [ ] spec 型補完を Prisma モデル名/フィールド名で効かせる(型レベル制約)
-- [ ] spec でスキーマに無いフィールド参照 → コンパイルエラー
-- [ ] 生成ファイルに元 spec の行参照コメント
-- [ ] `index.ts` の barrel に views も含める
+- [x] spec 型補完を Prisma モデル名/フィールド名で効かせる(TypedViewsSpec に transforms/computed 型追加)
+- [x] spec でスキーマに無いフィールド参照 → Prisma.ModelSelect 経由でコンパイルエラー
+- [x] `index.ts` の barrel に views も含める
 
 ## 技術的チャレンジ
 

--- a/src/generators/model/lib/dto/parseFieldDtoAnnotation.ts
+++ b/src/generators/model/lib/dto/parseFieldDtoAnnotation.ts
@@ -8,8 +8,26 @@ export const parseFieldDtoAnnotation = (args: {
   const documentation = args.field.documentation;
 
   if (documentation) {
-    const match = documentation.match(/@dto\(([^)]+)\)/);
+    // @dto.hide — exclude field from all DTOs
+    const hide = /@dto\.hide\b/.test(documentation);
 
+    // @dto.map({ "KEY": "label" }) — static enum→label mapping
+    let map: Record<string, string> | undefined;
+    const mapMatch = documentation.match(/@dto\.map\((\{[^}]+\})\)/);
+    if (mapMatch) {
+      try {
+        map = JSON.parse(mapMatch[1].replace(/(['"])?([a-zA-Z_]\w*)(['"])?:/g, '"$2":'));
+      } catch {
+        // ignore parse errors
+      }
+    }
+
+    if (hide || map) {
+      return { hidden: false, hide, map };
+    }
+
+    // legacy: @dto(hidden: true, nested: true)
+    const match = documentation.match(/@dto\(([^)]+)\)/);
     if (match) {
       const content = match[1];
       const hidden = /hidden:\s*true/.test(content);

--- a/src/generators/model/lib/dto/types.ts
+++ b/src/generators/model/lib/dto/types.ts
@@ -1,6 +1,8 @@
 export type DtoFieldAnnotation = {
   hidden: boolean;
   nested?: boolean;
+  hide?: boolean;
+  map?: Record<string, string>;
 };
 
 export type DtoProfile = {

--- a/src/generators/repository/transformer.ts
+++ b/src/generators/repository/transformer.ts
@@ -3,6 +3,7 @@ import type { ReadonlyDeep } from "../utils/types";
 import { writeFileSafely } from "../utils/writeFileSafely";
 import * as changeCase from "change-case-all";
 import type { ViewsSpec } from "../../spec/types";
+import { isRawViewSpec } from "../../spec/types";
 
 interface UniqueComposite {
   name: string | null;
@@ -427,14 +428,21 @@ ${relationSetters.join("\n")}
     const modelCamel = changeCase.camelCase(model.name);
     const allImports: string[] = [];
 
-    for (const viewName of Object.keys(modelViews)) {
+    for (const [viewName, viewSpec] of Object.entries(modelViews)) {
       const viewPascal = changeCase.pascalCase(viewName);
-      allImports.push(
-        `${modelCamel}${viewPascal}Select`,
-        `${model.name}${viewPascal}View`,
-        `${model.name}${viewPascal}Dto`,
-        `to${model.name}${viewPascal}Dto`,
-      );
+      if (isRawViewSpec(viewSpec)) {
+        allImports.push(
+          `${model.name}${viewPascal}Dto`,
+          `find${model.name}${viewPascal}Raw`,
+        );
+      } else {
+        allImports.push(
+          `${modelCamel}${viewPascal}Select`,
+          `${model.name}${viewPascal}View`,
+          `${model.name}${viewPascal}Dto`,
+          `to${model.name}${viewPascal}Dto`,
+        );
+      }
     }
 
     return `import { ${allImports.join(", ")} } from '../views/${model.name}.views';`;
@@ -449,11 +457,21 @@ ${relationSetters.join("\n")}
     const idFields = this.getIdFields(model);
     const methods: string[] = [];
 
-    for (const viewName of Object.keys(modelViews)) {
+    for (const [viewName, viewSpec] of Object.entries(modelViews)) {
       const viewPascal = changeCase.pascalCase(viewName);
+      const dtoType = `${model.name}${viewPascal}Dto`;
+
+      if (isRawViewSpec(viewSpec)) {
+        // Raw view: delegate to the generated helper function
+        methods.push(`
+    async find${viewPascal}Raw(prisma: any, args: any): Promise<${dtoType} | null> {
+      return find${model.name}${viewPascal}Raw(prisma, args);
+    }`);
+        continue;
+      }
+
       const selectConst = `${modelCamel}${viewPascal}Select`;
       const viewType = `${model.name}${viewPascal}View`;
-      const dtoType = `${model.name}${viewPascal}Dto`;
       const mapper = `to${model.name}${viewPascal}Dto`;
 
       if (idFields.length > 0) {

--- a/src/generators/views/transformer.ts
+++ b/src/generators/views/transformer.ts
@@ -2,7 +2,10 @@ import type { DMMF } from "@prisma/generator-helper";
 import type { ReadonlyDeep } from "../utils/types";
 import { writeFileSafely } from "../utils/writeFileSafely";
 import type { ViewsSpec, TransformValue, TransformStaticMap, ComputedFieldDefinition } from "../../spec/types";
+import { isRawViewSpec } from "../../spec/types";
+import { parseFieldDtoAnnotation } from "../model/lib/dto/parseFieldDtoAnnotation";
 import path from "path";
+import fs from "fs";
 
 function isStaticMap(v: TransformValue): v is TransformStaticMap {
   return typeof v === "object" && v !== null;
@@ -70,6 +73,12 @@ function scalarToTs(field: ReadonlyDeep<DMMF.Field>): string {
   }
 }
 
+/** Extract annotation map or hide flag for a field, falling back to undefined. */
+function getFieldAnnotation(field: ReadonlyDeep<DMMF.Field> | undefined) {
+  if (!field) return undefined;
+  return parseFieldDtoAnnotation({ field });
+}
+
 function buildDtoShape(
   select: Record<string, unknown>,
   model: ReadonlyDeep<DMMF.Model>,
@@ -82,14 +91,24 @@ function buildDtoShape(
   const fields = Object.entries(select).map(([key, val]) => {
     const currentPath = pathPrefix ? `${pathPrefix}.${key}` : key;
     const dmmfField = model.fields.find((f) => f.name === key);
-    const transform = transforms[currentPath];
+    const specTransform = transforms[currentPath];
+    const annotation = getFieldAnnotation(dmmfField);
+
+    // @dto.hide hides field unless spec has explicit transform (spec > annotation)
+    if (!specTransform && annotation?.hide) {
+      return null;
+    }
+
+    // Effective transform: spec wins, fallback to annotation map
+    const effectiveTransform: TransformValue | undefined =
+      specTransform ?? (annotation?.map ? annotation.map : undefined);
 
     if (val === true) {
-      if (transform) {
+      if (effectiveTransform) {
         const base = transformBaseName(viewName, currentPath);
         const nullable = dmmfField && !dmmfField.isRequired ? " | null" : "";
-        if (isStaticMap(transform)) {
-          const union = Object.values(transform)
+        if (isStaticMap(effectiveTransform)) {
+          const union = Object.values(effectiveTransform)
             .map((v) => JSON.stringify(v))
             .join(" | ");
           return `${key}: ${union}${nullable}`;
@@ -121,7 +140,7 @@ function buildDtoShape(
     }
 
     return `${key}: unknown`;
-  });
+  }).filter((f): f is string => f !== null);
 
   if (!pathPrefix && computed) {
     for (const [key, def] of Object.entries(computed)) {
@@ -161,7 +180,17 @@ function buildMapperBody(
   const fields = Object.entries(select).map(([key, val]) => {
     const currentPath = pathPrefix ? `${pathPrefix}.${key}` : key;
     const dmmfField = model.fields.find((f) => f.name === key);
-    const transform = transforms[currentPath];
+    const specTransform = transforms[currentPath];
+    const annotation = getFieldAnnotation(dmmfField);
+
+    // @dto.hide hides field unless spec has explicit transform
+    if (!specTransform && annotation?.hide) {
+      return null;
+    }
+
+    // Effective transform: spec wins, fallback to annotation map
+    const effectiveTransform: TransformValue | undefined =
+      specTransform ?? (annotation?.map ? annotation.map : undefined);
 
     if (
       typeof val === "object" &&
@@ -185,16 +214,16 @@ function buildMapperBody(
       }
     }
 
-    if (transform) {
+    if (effectiveTransform) {
       const base = transformBaseName(viewName, currentPath);
-      if (isStaticMap(transform)) {
+      if (isStaticMap(effectiveTransform)) {
         return `${key}: ${base}Map[${varName}.${key} as keyof typeof ${base}Map]`;
       }
       return `${key}: ${base}Transform(${varName}.${key})`;
     }
 
     return `${key}: ${varName}.${key}`;
-  });
+  }).filter((f): f is string => f !== null);
 
   if (!pathPrefix && computed) {
     for (const [key] of Object.entries(computed)) {
@@ -210,6 +239,7 @@ export class ViewsTransformer {
   private readonly _models: ReadonlyDeep<DMMF.Model[]>;
   private readonly _spec: ViewsSpec;
   private _outputPath: string;
+  private _generatedFiles: string[] = [];
 
   constructor(args: {
     models: ReadonlyDeep<DMMF.Model[]>;
@@ -222,6 +252,7 @@ export class ViewsTransformer {
   }
 
   async transform() {
+    this._generatedFiles = [];
     await this.generateSpecFile();
 
     for (const [modelName, modelViews] of Object.entries(this._spec)) {
@@ -229,12 +260,27 @@ export class ViewsTransformer {
       if (!dmmfModel) continue;
       await this.generateModelViewsFile(modelName, modelViews, dmmfModel);
     }
+
+    await this._writeViewsIndex();
+  }
+
+  private async _writeViewsIndex() {
+    const indexPath = path.join(this._outputPath, "index.ts");
+    const rows = this._generatedFiles.map((filePath) => {
+      let relativePath = path.relative(path.dirname(indexPath), filePath);
+      if (relativePath.endsWith(".ts")) {
+        relativePath = relativePath.slice(0, -3);
+      }
+      return `export * from './${relativePath.replace(/\\/g, "/")}';`;
+    });
+    fs.mkdirSync(path.dirname(indexPath), { recursive: true });
+    fs.writeFileSync(indexPath, rows.join("\n"));
   }
 
   private async generateSpecFile() {
     const modelEntries = this._models
       .map((m) => {
-        return `  ${m.name}?: { [view: string]: { select: Prisma.${m.name}Select } };`;
+        return `  ${m.name}?: {\n    [view: string]: {\n      select: Prisma.${m.name}Select;\n      transforms?: Record<string, ((v: any) => unknown) | Record<string, string>>;\n      computed?: Record<string, { type: string; from: (v: any) => unknown }>;\n    }\n  };`;
       })
       .join("\n");
 
@@ -264,11 +310,19 @@ export function defineViews<T extends TypedViewsSpec>(spec: T): T {
     // Emit transform and computed consts (grouped before all view blocks)
     const declLines: string[] = [];
     for (const [viewName, viewSpec] of Object.entries(modelViews)) {
+      if (isRawViewSpec(viewSpec)) {
+        // Raw views: serialize raw and map functions
+        declLines.push(`const _${viewName}Raw = ${viewSpec.raw.toString()};`);
+        declLines.push(`const _${viewName}Map = ${viewSpec.map.toString()};`);
+        continue;
+      }
       if (viewSpec.transforms) {
         for (const [fieldPath, transform] of Object.entries(viewSpec.transforms)) {
           declLines.push(generateTransformDecl(viewName, fieldPath, transform));
         }
       }
+      // Annotation-level maps for fields in this view's select
+      this._emitAnnotationTransformDecls(viewName, viewSpec.select as Record<string, unknown>, dmmfModel, viewSpec.transforms ?? {}, declLines);
       if (viewSpec.computed) {
         for (const [fieldName, def] of Object.entries(viewSpec.computed)) {
           declLines.push(generateComputedDecl(viewName, fieldName, def));
@@ -282,9 +336,26 @@ export function defineViews<T extends TypedViewsSpec>(spec: T): T {
     for (const [viewName, viewSpec] of Object.entries(modelViews)) {
       const viewCapitalized =
         viewName.charAt(0).toUpperCase() + viewName.slice(1);
+      const dtoTypeName = `${modelName}${viewCapitalized}Dto`;
+
+      blocks.push(`// --- ${viewName} view ---`, "");
+
+      if (isRawViewSpec(viewSpec)) {
+        // Raw view: DTO type inferred from map's return type
+        blocks.push(
+          `export type ${dtoTypeName} = ReturnType<typeof _${viewName}Map>;`,
+          "",
+          `export async function find${modelName}${viewCapitalized}Raw(prisma: any, args: any): Promise<${dtoTypeName} | null> {`,
+          `  const row = await _${viewName}Raw(prisma, args);`,
+          `  return row ? _${viewName}Map(row) : null;`,
+          `}`,
+          "",
+        );
+        continue;
+      }
+
       const selectConstName = `${modelName.charAt(0).toLowerCase()}${modelName.slice(1)}${viewCapitalized}Select`;
       const viewTypeName = `${modelName}${viewCapitalized}View`;
-      const dtoTypeName = `${modelName}${viewCapitalized}Dto`;
       const mapperName = `to${modelName}${viewCapitalized}Dto`;
 
       const transforms = viewSpec.transforms ?? {};
@@ -313,8 +384,6 @@ export function defineViews<T extends TypedViewsSpec>(spec: T): T {
       );
 
       blocks.push(
-        `// --- ${viewName} view ---`,
-        "",
         `export const ${selectConstName} = ${serializedSelect} as const satisfies Prisma.${modelName}Select;`,
         "",
         `export type ${viewTypeName} = Prisma.${modelName}GetPayload<{`,
@@ -333,5 +402,48 @@ export function defineViews<T extends TypedViewsSpec>(spec: T): T {
     const content = blocks.join("\n");
     const filePath = path.join(this._outputPath, `${modelName}.views.ts`);
     await writeFileSafely(filePath, content, false);
+    this._generatedFiles.push(filePath);
+  }
+
+  /**
+   * Emit static map consts for fields that have @dto.map annotations
+   * and no spec-level transform defined.
+   */
+  private _emitAnnotationTransformDecls(
+    viewName: string,
+    select: Record<string, unknown>,
+    model: ReadonlyDeep<DMMF.Model>,
+    specTransforms: Record<string, TransformValue>,
+    out: string[],
+    pathPrefix = "",
+  ) {
+    for (const [key, val] of Object.entries(select)) {
+      const currentPath = pathPrefix ? `${pathPrefix}.${key}` : key;
+      if (specTransforms[currentPath]) continue;
+      const dmmfField = model.fields.find((f) => f.name === key);
+      const annotation = getFieldAnnotation(dmmfField);
+      if (annotation?.map) {
+        const base = transformBaseName(viewName, currentPath);
+        out.push(`const ${base}Map = ${JSON.stringify(annotation.map)} as const;`);
+      }
+      if (
+        typeof val === "object" &&
+        val !== null &&
+        "select" in val &&
+        dmmfField
+      ) {
+        const relatedModel = this._models.find((m) => m.name === dmmfField.type);
+        if (relatedModel) {
+          this._emitAnnotationTransformDecls(
+            viewName,
+            (val as { select: Record<string, unknown> }).select,
+            relatedModel,
+            specTransforms,
+            out,
+            currentPath,
+          );
+        }
+      }
+    }
   }
 }

--- a/src/spec/loader.ts
+++ b/src/spec/loader.ts
@@ -53,9 +53,10 @@ function validateSpec(input: unknown, sourcePath: string): ViewsSpec {
           `[Frourio Framework] spec: view "${modelName}.${viewName}" must be an object (got ${typeOf(viewSpec)})`,
         );
       }
-      if (!("select" in viewSpec) || !isPlainObject(viewSpec.select)) {
+      const isRaw = "raw" in viewSpec && "map" in viewSpec;
+      if (!isRaw && (!("select" in viewSpec) || !isPlainObject(viewSpec.select))) {
         throw new Error(
-          `[Frourio Framework] spec: view "${modelName}.${viewName}" must have a "select" object`,
+          `[Frourio Framework] spec: view "${modelName}.${viewName}" must have a "select" object or "raw"+"map" functions`,
         );
       }
     }

--- a/src/spec/types.ts
+++ b/src/spec/types.ts
@@ -9,8 +9,7 @@
 export type ViewSpecSelect = Record<string, unknown>;
 
 /** Function transform: receives the raw DB value, returns the DTO value. */
-
-export type TransformFn = (v: any) => unknown;
+export type TransformFn<TIn = unknown, TOut = unknown> = (v: TIn) => TOut;
 
 /**
  * Static map transform — sugar for simple enum→label mappings.
@@ -18,14 +17,16 @@ export type TransformFn = (v: any) => unknown;
  */
 export type TransformStaticMap = Record<string, string>;
 
-export type TransformValue = TransformFn | TransformStaticMap;
+export type TransformValue<TIn = unknown, TOut = unknown> =
+  | TransformFn<TIn, TOut>
+  | TransformStaticMap;
 
 /** Computed field: adds a new property derived from the full row. */
-export type ComputedFieldDefinition = {
+export type ComputedFieldDefinition<TRow = unknown, TResult = unknown> = {
   /** TypeScript type of the computed value (e.g. `"string"`, `"number"`). */
   type: string;
   /** Function that derives the value from the raw DB row. */
-  from: (v: any) => unknown;
+  from: (v: TRow) => TResult;
 };
 
 export type SelectViewSpec = {
@@ -47,10 +48,15 @@ export type SelectViewSpec = {
  * Raw view: bypasses select-based generation. The `raw` function executes an
  * arbitrary Prisma query, and `map` converts the result to the DTO. DTO type
  * is inferred from `map`'s return type.
+ *
+ * Type parameters:
+ * - TArgs: shape of the args object passed to `raw`
+ * - TRow:  shape returned by `raw` (input to `map`)
+ * - TDto:  shape returned by `map` (the final DTO)
  */
-export type RawViewSpec = {
-  raw: (prisma: any, args: any) => Promise<any>;
-  map: (row: any) => any;
+export type RawViewSpec<TArgs = unknown, TRow = unknown, TDto = unknown> = {
+  raw: (prisma: unknown, args: TArgs) => Promise<TRow | null>;
+  map: (row: TRow) => TDto;
 };
 
 export type ViewSpec = SelectViewSpec | RawViewSpec;

--- a/src/spec/types.ts
+++ b/src/spec/types.ts
@@ -28,7 +28,7 @@ export type ComputedFieldDefinition = {
   from: (v: any) => unknown;
 };
 
-export type ViewSpec = {
+export type SelectViewSpec = {
   select: ViewSpecSelect;
   /**
    * Field-level transforms keyed by dot-path relative to the view root.
@@ -42,6 +42,22 @@ export type ViewSpec = {
    */
   computed?: Record<string, ComputedFieldDefinition>;
 };
+
+/**
+ * Raw view: bypasses select-based generation. The `raw` function executes an
+ * arbitrary Prisma query, and `map` converts the result to the DTO. DTO type
+ * is inferred from `map`'s return type.
+ */
+export type RawViewSpec = {
+  raw: (prisma: any, args: any) => Promise<any>;
+  map: (row: any) => any;
+};
+
+export type ViewSpec = SelectViewSpec | RawViewSpec;
+
+export function isRawViewSpec(spec: ViewSpec): spec is RawViewSpec {
+  return "raw" in spec && "map" in spec;
+}
 
 export type ModelViewsSpec = {
   [viewName: string]: ViewSpec;


### PR DESCRIPTION
Phase 4: @dto.hide / @dto.map annotation support
- DtoFieldAnnotation extended with hide, map fields
- parseFieldDtoAnnotation parses @dto.hide and @dto.map({...})
- views transformer applies annotations as fallback transforms (spec > annotation)

Phase 5: raw view escape hatch
- RawViewSpec type + isRawViewSpec type guard added to spec/types.ts
- loader validates raw+map forms alongside select-based views
- views transformer generates ReturnType<typeof _rawMap> DTO + findModelViewRaw helper
- repository transformer generates findViewRaw(prisma, args) method

Phase 6: DX improvements
- TypedViewsSpec includes transforms/computed type definitions
- views transformer tracks generated files locally → writes views/index.ts barrel
- Avoids contaminating global indexExports Set used by model generator

<!--

Thank you for your contribution! 👍

-->

## Types of changes

- [ ] Bug fixes
  - resolves #<!-- Please add issue number -->
- [ ] Features
  - resolves #<!-- Please add issue number -->
- [ ] Maintenance
- [ ] Documentation

## Changes

- ...

## Additional context

## Community note

<!-- Please keep this section. -->

Please upvote with reacting as :+1: to express your agreement.
