### PR TITLE
fix: normalize dto.config pick/omit to camelCase field names

### DIFF
--- a/prisma/dto.config.ts
+++ b/prisma/dto.config.ts
@@ -66,7 +66,7 @@ export default registerModelDtos([
   defineModelDto("Company", {
     base: {
       fields: {
-        bank_info: { jsonType: "BankInfo" },
+        bankInfo: { jsonType: "BankInfo" },
       },
     },
   }),

--- a/src/generators/model/transformer.ts
+++ b/src/generators/model/transformer.ts
@@ -7,6 +7,8 @@ import { parseFieldDtoAnnotation } from "./lib/dto/parseFieldDtoAnnotation";
 import { parseModelDtoProfiles } from "./lib/dto/parseModelDtoProfiles";
 import type { DtoProfile } from "./lib/dto/types";
 import type { LoadedSpec } from "../../spec/types";
+import type { FieldBaseConfig } from "../../spec/types";
+import { normalizeFieldName } from "../utils/normalizeFieldName";
 
 export default class Transformer {
   private readonly _models: ReadonlyDeep<PrismaDMMF.Model[]> = [];
@@ -142,6 +144,14 @@ export default class Transformer {
     return `${renderKey}: ${args.overrideValue ? args.overrideValue : this.mapPrismaValueType({ field: args.field })}${requiredOrNullValue}`;
   }
 
+  private resolveSpecFieldConfig(
+    specFields: Record<string, FieldBaseConfig>,
+    fieldName: string,
+  ): FieldBaseConfig | undefined {
+    const normalized = normalizeFieldName(fieldName);
+    return specFields[normalized] ?? specFields[fieldName];
+  }
+
   private getHiddenFieldNames(args: { model: PrismaDMMF.Model }): Set<string> {
     const hidden = new Set<string>();
     const specFields = this._spec?.base[args.model.name]?.fields ?? {};
@@ -150,7 +160,7 @@ export default class Transformer {
       if (annotation?.hidden || annotation?.hide) {
         hidden.add(field.name);
       }
-      if (specFields[field.name]?.hide) {
+      if (this.resolveSpecFieldConfig(specFields, field.name)?.hide) {
         hidden.add(field.name);
       }
     }
@@ -163,7 +173,10 @@ export default class Transformer {
     for (const field of args.model.fields) {
       if (field.relationName) {
         const annotation = parseFieldDtoAnnotation({ field });
-        if (annotation?.nested || specFields[field.name]?.nested) {
+        if (
+          annotation?.nested ||
+          this.resolveSpecFieldConfig(specFields, field.name)?.nested
+        ) {
           nested.add(field.name);
         }
       }
@@ -182,6 +195,10 @@ export default class Transformer {
     return [...merged.values()];
   }
 
+  private normalizeProfileFieldNames(names: string[]): string[] {
+    return names.map((name) => normalizeFieldName(name));
+  }
+
   private getProfileFields(args: {
     model: PrismaDMMF.Model;
     profile: DtoProfile;
@@ -189,7 +206,8 @@ export default class Transformer {
     const fieldNames = new Set(args.model.fields.map((f) => f.name));
 
     if (args.profile.pick) {
-      const unknownPick = args.profile.pick.filter((name) => !fieldNames.has(name));
+      const normalizedPick = this.normalizeProfileFieldNames(args.profile.pick);
+      const unknownPick = normalizedPick.filter((name) => !fieldNames.has(name));
       if (unknownPick.length > 0) {
         throw new Error(
           `[Frourio Framework] profile "${args.profile.name}" on model "${args.model.name}": ` +
@@ -197,11 +215,13 @@ export default class Transformer {
             `Valid fields are: ${[...fieldNames].map((n) => `"${n}"`).join(", ")}.`,
         );
       }
-      return args.model.fields.filter((f) => args.profile.pick!.includes(f.name));
+      const pickSet = new Set(normalizedPick);
+      return args.model.fields.filter((f) => pickSet.has(f.name));
     }
 
     if (args.profile.omit) {
-      const unknownOmit = args.profile.omit.filter((name) => !fieldNames.has(name));
+      const normalizedOmit = this.normalizeProfileFieldNames(args.profile.omit);
+      const unknownOmit = normalizedOmit.filter((name) => !fieldNames.has(name));
       if (unknownOmit.length > 0) {
         throw new Error(
           `[Frourio Framework] profile "${args.profile.name}" on model "${args.model.name}": ` +
@@ -209,7 +229,7 @@ export default class Transformer {
             `Valid fields are: ${[...fieldNames].map((n) => `"${n}"`).join(", ")}.`,
         );
       }
-      const omitSet = new Set(args.profile.omit);
+      const omitSet = new Set(normalizedOmit);
       return args.model.fields.filter((f) => !omitSet.has(f.name));
     }
 

--- a/src/generators/utils/normalizeFieldName.ts
+++ b/src/generators/utils/normalizeFieldName.ts
@@ -4,6 +4,6 @@ import { camelCase } from "change-case-all";
  * Normalizes a Prisma/schema field identifier to the camelCase name used in
  * generated model classes and dto.config.ts.
  *
- * Examples: `user_id` → `userId`, `phoneNumber` → `phoneNumber`
+ * Examples: `external_id` → `externalId`, `phoneNumber` → `phoneNumber`
  */
 export const normalizeFieldName = (name: string): string => camelCase(name);

--- a/src/generators/utils/normalizeFieldName.ts
+++ b/src/generators/utils/normalizeFieldName.ts
@@ -4,6 +4,6 @@ import { camelCase } from "change-case-all";
  * Normalizes a Prisma/schema field identifier to the camelCase name used in
  * generated model classes and dto.config.ts.
  *
- * Examples: `myfans_id` → `myfansId`, `phoneNumber` → `phoneNumber`
+ * Examples: `user_id` → `userId`, `phoneNumber` → `phoneNumber`
  */
 export const normalizeFieldName = (name: string): string => camelCase(name);

--- a/src/generators/utils/normalizeFieldName.ts
+++ b/src/generators/utils/normalizeFieldName.ts
@@ -1,0 +1,9 @@
+import { camelCase } from "change-case-all";
+
+/**
+ * Normalizes a Prisma/schema field identifier to the camelCase name used in
+ * generated model classes and dto.config.ts.
+ *
+ * Examples: `myfans_id` → `myfansId`, `phoneNumber` → `phoneNumber`
+ */
+export const normalizeFieldName = (name: string): string => camelCase(name);

--- a/src/spec/defineModelDto.ts
+++ b/src/spec/defineModelDto.ts
@@ -24,10 +24,15 @@ type ModelRelationName<TName extends Prisma.ModelName> = Extract<
   string
 >;
 
-/** All field names (scalars + relation objects) for a given model. */
+/** Converts snake_case Prisma field names to camelCase (generated model convention). */
+type CamelCaseFieldName<S extends string> = S extends `${infer Head}_${infer Tail}`
+  ? `${Head}${Capitalize<CamelCaseFieldName<Tail>>}`
+  : S;
+
+/** All field names (scalars + relation objects) in camelCase — dto.config.ts convention. */
 type ModelFieldName<TName extends Prisma.ModelName> =
-  | Extract<keyof ModelScalars<TName>, string>
-  | ModelRelationName<TName>;
+  | CamelCaseFieldName<Extract<keyof ModelScalars<TName>, string>>
+  | CamelCaseFieldName<ModelRelationName<TName>>;
 
 /**
  * Transform map typed per scalar field plus nested dot-paths under relations.

--- a/tests/modelTransformer.test.ts
+++ b/tests/modelTransformer.test.ts
@@ -1009,5 +1009,109 @@ describe("Model Transformer", () => {
       const content = findModelContent("User.model.ts");
       expect(content).toContain("export type UserPublicDto");
     });
+
+    it("normalizes snake_case omit fields from spec to camelCase model fields", async () => {
+      const model = makeModel("MCreator", [
+        makeField({ name: "id", type: "Int", isId: true }),
+        makeField({ name: "name", type: "String" }),
+        makeField({ name: "phone_number", type: "String", isRequired: false }),
+        makeField({ name: "myfans_id", type: "String", isRequired: false }),
+        makeField({ name: "avple_id", type: "String", isRequired: false }),
+      ]);
+
+      const t = new Transformer({ models: [model] });
+      t.setOutputPath({ path: "/tmp/test-output" });
+      t.setSpec({
+        spec: {
+          _type: "LoadedSpec",
+          views: {},
+          base: {
+            MCreator: {
+              fields: {
+                phoneNumber: { hide: true },
+                myfansId: { hide: true },
+                avpleId: { hide: true },
+              },
+              profiles: [
+                {
+                  name: "Owner",
+                  omit: ["myfansId", "avpleId"],
+                },
+                { name: "Admin", omit: [] },
+              ],
+            },
+          },
+        },
+      });
+
+      await expect(t.transform()).resolves.not.toThrow();
+      const content = findModelContent("MCreator.model.ts");
+
+      const ownerDtoMatch = content.match(
+        /export type MCreatorOwnerDto = \{([^}]+)\}/,
+      );
+      expect(ownerDtoMatch).toBeTruthy();
+      expect(ownerDtoMatch![1]).toContain("name");
+      expect(ownerDtoMatch![1]).not.toContain("myfansId");
+      expect(ownerDtoMatch![1]).not.toContain("avpleId");
+      // hide applies to base toDto(), not profile DTOs unless explicitly omitted
+      expect(ownerDtoMatch![1]).toContain("phoneNumber");
+    });
+
+    it("normalizes snake_case pick/omit from @dto.profile schema annotations", async () => {
+      const model = makeModel(
+        "MCreator",
+        [
+          makeField({ name: "id", type: "Int", isId: true }),
+          makeField({ name: "name", type: "String" }),
+          makeField({ name: "myfans_id", type: "String", isRequired: false }),
+          makeField({ name: "avple_id", type: "String", isRequired: false }),
+        ],
+        {
+          documentation:
+            "@dto.profile(name: Owner, omit: [myfans_id, avple_id])",
+        },
+      );
+
+      const t = new Transformer({ models: [model] });
+      t.setOutputPath({ path: "/tmp/test-output" });
+      await t.transform();
+
+      const content = findModelContent("MCreator.model.ts");
+      const ownerDtoMatch = content.match(
+        /export type MCreatorOwnerDto = \{([^}]+)\}/,
+      );
+      expect(ownerDtoMatch).toBeTruthy();
+      expect(ownerDtoMatch![1]).toContain("name");
+      expect(ownerDtoMatch![1]).not.toContain("myfansId");
+      expect(ownerDtoMatch![1]).not.toContain("avpleId");
+    });
+
+    it("accepts snake_case omit aliases in spec (backward compatibility)", async () => {
+      const model = makeModel("MCreator", [
+        makeField({ name: "id", type: "Int", isId: true }),
+        makeField({ name: "myfans_id", type: "String", isRequired: false }),
+      ]);
+
+      const t = new Transformer({ models: [model] });
+      t.setOutputPath({ path: "/tmp/test-output" });
+      t.setSpec({
+        spec: {
+          _type: "LoadedSpec",
+          views: {},
+          base: {
+            MCreator: {
+              profiles: [{ name: "Public", omit: ["myfans_id"] }],
+            },
+          },
+        },
+      });
+
+      await expect(t.transform()).resolves.not.toThrow();
+      const content = findModelContent("MCreator.model.ts");
+      const dtoMatch = content.match(/export type MCreatorPublicDto = \{([^}]+)\}/);
+      expect(dtoMatch).toBeTruthy();
+      expect(dtoMatch![1]).not.toContain("myfansId");
+    });
   });
 });

--- a/tests/modelTransformer.test.ts
+++ b/tests/modelTransformer.test.ts
@@ -1011,12 +1011,12 @@ describe("Model Transformer", () => {
     });
 
     it("normalizes snake_case omit fields from spec to camelCase model fields", async () => {
-      const model = makeModel("MCreator", [
+      const model = makeModel("Account", [
         makeField({ name: "id", type: "Int", isId: true }),
         makeField({ name: "name", type: "String" }),
         makeField({ name: "phone_number", type: "String", isRequired: false }),
-        makeField({ name: "myfans_id", type: "String", isRequired: false }),
-        makeField({ name: "avple_id", type: "String", isRequired: false }),
+        makeField({ name: "external_id", type: "String", isRequired: false }),
+        makeField({ name: "internal_code", type: "String", isRequired: false }),
       ]);
 
       const t = new Transformer({ models: [model] });
@@ -1026,16 +1026,16 @@ describe("Model Transformer", () => {
           _type: "LoadedSpec",
           views: {},
           base: {
-            MCreator: {
+            Account: {
               fields: {
                 phoneNumber: { hide: true },
-                myfansId: { hide: true },
-                avpleId: { hide: true },
+                externalId: { hide: true },
+                internalCode: { hide: true },
               },
               profiles: [
                 {
                   name: "Owner",
-                  omit: ["myfansId", "avpleId"],
+                  omit: ["externalId", "internalCode"],
                 },
                 { name: "Admin", omit: [] },
               ],
@@ -1045,31 +1045,31 @@ describe("Model Transformer", () => {
       });
 
       await expect(t.transform()).resolves.not.toThrow();
-      const content = findModelContent("MCreator.model.ts");
+      const content = findModelContent("Account.model.ts");
 
       const ownerDtoMatch = content.match(
-        /export type MCreatorOwnerDto = \{([^}]+)\}/,
+        /export type AccountOwnerDto = \{([^}]+)\}/,
       );
       expect(ownerDtoMatch).toBeTruthy();
       expect(ownerDtoMatch![1]).toContain("name");
-      expect(ownerDtoMatch![1]).not.toContain("myfansId");
-      expect(ownerDtoMatch![1]).not.toContain("avpleId");
+      expect(ownerDtoMatch![1]).not.toContain("externalId");
+      expect(ownerDtoMatch![1]).not.toContain("internalCode");
       // hide applies to base toDto(), not profile DTOs unless explicitly omitted
       expect(ownerDtoMatch![1]).toContain("phoneNumber");
     });
 
     it("normalizes snake_case pick/omit from @dto.profile schema annotations", async () => {
       const model = makeModel(
-        "MCreator",
+        "Account",
         [
           makeField({ name: "id", type: "Int", isId: true }),
           makeField({ name: "name", type: "String" }),
-          makeField({ name: "myfans_id", type: "String", isRequired: false }),
-          makeField({ name: "avple_id", type: "String", isRequired: false }),
+          makeField({ name: "external_id", type: "String", isRequired: false }),
+          makeField({ name: "internal_code", type: "String", isRequired: false }),
         ],
         {
           documentation:
-            "@dto.profile(name: Owner, omit: [myfans_id, avple_id])",
+            "@dto.profile(name: Owner, omit: [external_id, internal_code])",
         },
       );
 
@@ -1077,20 +1077,20 @@ describe("Model Transformer", () => {
       t.setOutputPath({ path: "/tmp/test-output" });
       await t.transform();
 
-      const content = findModelContent("MCreator.model.ts");
+      const content = findModelContent("Account.model.ts");
       const ownerDtoMatch = content.match(
-        /export type MCreatorOwnerDto = \{([^}]+)\}/,
+        /export type AccountOwnerDto = \{([^}]+)\}/,
       );
       expect(ownerDtoMatch).toBeTruthy();
       expect(ownerDtoMatch![1]).toContain("name");
-      expect(ownerDtoMatch![1]).not.toContain("myfansId");
-      expect(ownerDtoMatch![1]).not.toContain("avpleId");
+      expect(ownerDtoMatch![1]).not.toContain("externalId");
+      expect(ownerDtoMatch![1]).not.toContain("internalCode");
     });
 
     it("accepts snake_case omit aliases in spec (backward compatibility)", async () => {
-      const model = makeModel("MCreator", [
+      const model = makeModel("Account", [
         makeField({ name: "id", type: "Int", isId: true }),
-        makeField({ name: "myfans_id", type: "String", isRequired: false }),
+        makeField({ name: "external_id", type: "String", isRequired: false }),
       ]);
 
       const t = new Transformer({ models: [model] });
@@ -1100,18 +1100,18 @@ describe("Model Transformer", () => {
           _type: "LoadedSpec",
           views: {},
           base: {
-            MCreator: {
-              profiles: [{ name: "Public", omit: ["myfans_id"] }],
+            Account: {
+              profiles: [{ name: "Public", omit: ["external_id"] }],
             },
           },
         },
       });
 
       await expect(t.transform()).resolves.not.toThrow();
-      const content = findModelContent("MCreator.model.ts");
-      const dtoMatch = content.match(/export type MCreatorPublicDto = \{([^}]+)\}/);
+      const content = findModelContent("Account.model.ts");
+      const dtoMatch = content.match(/export type AccountPublicDto = \{([^}]+)\}/);
       expect(dtoMatch).toBeTruthy();
-      expect(dtoMatch![1]).not.toContain("myfansId");
+      expect(dtoMatch![1]).not.toContain("externalId");
     });
   });
 });

--- a/tests/normalizeFieldName.test.ts
+++ b/tests/normalizeFieldName.test.ts
@@ -3,14 +3,14 @@ import { normalizeFieldName } from "../src/generators/utils/normalizeFieldName";
 
 describe("normalizeFieldName", () => {
   it("converts snake_case to camelCase", () => {
-    expect(normalizeFieldName("myfans_id")).toBe("myfansId");
-    expect(normalizeFieldName("avple_id")).toBe("avpleId");
+    expect(normalizeFieldName("external_id")).toBe("externalId");
+    expect(normalizeFieldName("internal_code")).toBe("internalCode");
     expect(normalizeFieldName("phone_number")).toBe("phoneNumber");
     expect(normalizeFieldName("bank_info")).toBe("bankInfo");
   });
 
   it("leaves camelCase names unchanged", () => {
-    expect(normalizeFieldName("myfansId")).toBe("myfansId");
+    expect(normalizeFieldName("externalId")).toBe("externalId");
     expect(normalizeFieldName("phoneNumber")).toBe("phoneNumber");
     expect(normalizeFieldName("id")).toBe("id");
   });

--- a/tests/normalizeFieldName.test.ts
+++ b/tests/normalizeFieldName.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { normalizeFieldName } from "../src/generators/utils/normalizeFieldName";
+
+describe("normalizeFieldName", () => {
+  it("converts snake_case to camelCase", () => {
+    expect(normalizeFieldName("myfans_id")).toBe("myfansId");
+    expect(normalizeFieldName("avple_id")).toBe("avpleId");
+    expect(normalizeFieldName("phone_number")).toBe("phoneNumber");
+    expect(normalizeFieldName("bank_info")).toBe("bankInfo");
+  });
+
+  it("leaves camelCase names unchanged", () => {
+    expect(normalizeFieldName("myfansId")).toBe("myfansId");
+    expect(normalizeFieldName("phoneNumber")).toBe("phoneNumber");
+    expect(normalizeFieldName("id")).toBe("id");
+  });
+});

--- a/tests/types-defineModelDto.test-d.ts
+++ b/tests/types-defineModelDto.test-d.ts
@@ -70,3 +70,14 @@ defineViews({
   // @ts-expect-error — "NonExistent" is not a Prisma model
   NonExistent: { all: { select: { id: true } } },
 });
+
+// ─── snake_case Prisma fields are referenced as camelCase in dto.config.ts ──
+defineModelDto("Company", {
+  base: {
+    fields: {
+      bankInfo: { jsonType: "BankInfo" },
+      // @ts-expect-error — use camelCase (bankInfo), not schema name (bank_info)
+      bank_info: { jsonType: "BankInfo" },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- `pick` / `omit` in `dto.config.ts` profiles and `@dto.profile` schema annotations are now normalized to camelCase before matching generated model fields, so snake_case Prisma fields (e.g. `myfans_id`) work without `as 'myfans_id'` type assertions.
- Spec `fields` lookups for `hide` / `nested` also resolve camelCase keys consistently (same convention as existing `jsonType` lookup).
- `defineModelDto` TypeScript types now expect camelCase field names (`bankInfo` instead of `bank_info`), matching generated model output.

## Test plan

- [x] `npm test` — 117 tests pass
- [x] `npm run typecheck` — passes
- [x] Added tests for snake_case profile omit via spec and `@dto.profile` annotation
- [x] Added type-level test ensuring `bank_info` is rejected in favor of `bankInfo`


Made with [Cursor](https://cursor.com)